### PR TITLE
Add -fPIC and rm OBJECT

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -147,7 +147,7 @@ set(CMAKE_CXX_FLAGS
     "${CMAKE_CXX_FLAGS} -mavx2 -mfma -mavx -mf16c -mbmi2 -mbmi -D USE_VELOX_COMMON_BASE"
 )
 
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D HAS_UNCAUGHT_EXCEPTIONS")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -D HAS_UNCAUGHT_EXCEPTIONS -fPIC")
 
 # Under Ninja, we are able to designate certain targets large enough to require
 # restricted parallelism.

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-add_library(velox_hive_connector OBJECT HiveConnector.cpp FileHandle.cpp)
+add_library(velox_hive_connector HiveConnector.cpp FileHandle.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector
                       velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)

--- a/velox/functions/prestosql/CMakeLists.txt
+++ b/velox/functions/prestosql/CMakeLists.txt
@@ -16,7 +16,7 @@ add_subdirectory(hyperloglog)
 add_subdirectory(types)
 
 add_library(
-  velox_functions_prestosql_impl OBJECT
+  velox_functions_prestosql_impl
   ArrayConstructor.cpp
   ArrayContains.cpp
   ArrayDistinct.cpp

--- a/velox/functions/prestosql/aggregates/CMakeLists.txt
+++ b/velox/functions/prestosql/aggregates/CMakeLists.txt
@@ -17,7 +17,7 @@ if(${VELOX_BUILD_TESTING})
 endif()
 
 add_library(
-  velox_aggregates OBJECT
+  velox_aggregates
   AggregateNames.h
   ApproxDistinctAggregate.cpp
   ApproxPercentileAggregate.cpp


### PR DESCRIPTION
To use Velox in a shared library, its static libraries should be compiled into position independent code.
Several OBJECT settings in Velox was removed, about which an issue was raised to Velox and the issue id is 1047.