### PR TITLE
Remove velox prefix in proto files

### DIFF
--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package substrait;
 
-import "velox/substrait/proto/substrait/type.proto";
-import "velox/substrait/proto/substrait/extensions/extensions.proto";
+import "substrait/type.proto";
+import "substrait/extensions/extensions.proto";
 import "google/protobuf/any.proto";
 
 option java_multiple_files = true;

--- a/velox/substrait/proto/substrait/function.proto
+++ b/velox/substrait/proto/substrait/function.proto
@@ -2,9 +2,9 @@ syntax = "proto3";
 
 package substrait;
 
-import "velox/substrait/proto/substrait/type.proto";
-import "velox/substrait/proto/substrait/parameterized_types.proto";
-import "velox/substrait/proto/substrait/type_expressions.proto";
+import "substrait/type.proto";
+import "substrait/parameterized_types.proto";
+import "substrait/type_expressions.proto";
 
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";

--- a/velox/substrait/proto/substrait/parameterized_types.proto
+++ b/velox/substrait/proto/substrait/parameterized_types.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package substrait;
 
-import "velox/substrait/proto/substrait/type.proto";
+import "substrait/type.proto";
 
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";

--- a/velox/substrait/proto/substrait/plan.proto
+++ b/velox/substrait/proto/substrait/plan.proto
@@ -2,8 +2,8 @@ syntax = "proto3";
 
 package substrait;
 
-import "velox/substrait/proto/substrait/algebra.proto";
-import "velox/substrait/proto/substrait/extensions/extensions.proto";
+import "substrait/algebra.proto";
+import "substrait/extensions/extensions.proto";
 
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";

--- a/velox/substrait/proto/substrait/type_expressions.proto
+++ b/velox/substrait/proto/substrait/type_expressions.proto
@@ -1,7 +1,7 @@
 syntax = "proto3";
 package substrait;
 
-import "velox/substrait/proto/substrait/type.proto";
+import "substrait/type.proto";
 
 option java_multiple_files = true;
 option java_package = "io.substrait.proto";


### PR DESCRIPTION
To satisfy the needs of Meta's internal tests, the Substrait proto files were added with some Velox prefixes, which would cause compilation failure on other test environments. This PR removed them. 