### PR TITLE
Fix agg step when only groupings exist

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -630,6 +630,11 @@ std::string SubstraitVeloxPlanConverter::findFuncSpec(uint64_t id) {
 bool SubstraitVeloxPlanConverter::needsRowConstruct(
     const ::substrait::AggregateRel& sAgg,
     core::AggregationNode::Step& aggStep) {
+  if (sAgg.measures().size() == 0) {
+    // When only groupings exist, set the phase to be Single.
+    aggStep = core::AggregationNode::Step::kSingle;
+    return false;
+  }
   for (const auto& smea : sAgg.measures()) {
     auto aggFunction = smea.measure();
     std::string funcName = subParser_->findVeloxFunction(


### PR DESCRIPTION
When only groupings exist, the phase was not set which caused failure in plan print. This PR fixed this issue.