### PR TITLE
[OPPRO-46] Support Parquet Read

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -418,7 +418,8 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
     u_int32_t& index,
     std::vector<std::string>& paths,
     std::vector<u_int64_t>& starts,
-    std::vector<u_int64_t>& lengths) {
+    std::vector<u_int64_t>& lengths,
+    int& fileFormat) {
   // Check if the ReadRel specifies an input of stream. If yes, the pre-built
   // input node will be used as the data source.
   auto streamIdx = streamIsInput(sRead);
@@ -454,6 +455,7 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
     starts.reserve(fileList.size());
     lengths.reserve(fileList.size());
     for (const auto& file : fileList) {
+      fileFormat = file.format();
       // Expect all Partitions share the same index.
       index = file.partition_index();
       paths.emplace_back(file.uri_file());
@@ -531,7 +533,7 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
     return toVeloxPlan(sRel.join());
   }
   if (sRel.has_read()) {
-    return toVeloxPlan(sRel.read(), partitionIndex_, paths_, starts_, lengths_);
+    return toVeloxPlan(sRel.read(), partitionIndex_, paths_, starts_, lengths_, fileFormat_);
   }
   VELOX_NYI("Substrait conversion not supported for Rel.");
 }

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -415,11 +415,7 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
 
 std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
     const ::substrait::ReadRel& sRead,
-    u_int32_t& index,
-    std::vector<std::string>& paths,
-    std::vector<u_int64_t>& starts,
-    std::vector<u_int64_t>& lengths,
-    int& fileFormat) {
+    std::shared_ptr<SplitInfo>& splitInfo) {
   // Check if the ReadRel specifies an input of stream. If yes, the pre-built
   // input node will be used as the data source.
   auto streamIdx = streamIsInput(sRead);
@@ -451,16 +447,23 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
   // Parse local files
   if (sRead.has_local_files()) {
     const auto& fileList = sRead.local_files().items();
-    paths.reserve(fileList.size());
-    starts.reserve(fileList.size());
-    lengths.reserve(fileList.size());
+    splitInfo->paths.reserve(fileList.size());
+    splitInfo->starts.reserve(fileList.size());
+    splitInfo->lengths.reserve(fileList.size());
     for (const auto& file : fileList) {
-      fileFormat = file.format();
       // Expect all Partitions share the same index.
-      index = file.partition_index();
-      paths.emplace_back(file.uri_file());
-      starts.emplace_back(file.start());
-      lengths.emplace_back(file.length());
+      splitInfo->partitionIndex = file.partition_index();
+      splitInfo->paths.emplace_back(file.uri_file());
+      splitInfo->starts.emplace_back(file.start());
+      splitInfo->lengths.emplace_back(file.length());
+      auto format = file.format();
+      if (format == 0) {
+        splitInfo->format = dwio::common::FileFormat::ORC;
+      } else if (format == 1) {
+        splitInfo->format = dwio::common::FileFormat::PARQUET;
+      } else {
+        splitInfo->format = dwio::common::FileFormat::UNKNOWN;
+      }
     }
   }
 
@@ -533,7 +536,11 @@ std::shared_ptr<const core::PlanNode> SubstraitVeloxPlanConverter::toVeloxPlan(
     return toVeloxPlan(sRel.join());
   }
   if (sRel.has_read()) {
-    return toVeloxPlan(sRel.read(), partitionIndex_, paths_, starts_, lengths_, fileFormat_);
+    auto splitInfo = std::make_shared<SplitInfo>();
+
+    auto planNode = toVeloxPlan(sRel.read(), splitInfo);
+    splitInfoMap_[planNode->id()] = splitInfo;
+    return planNode;
   }
   VELOX_NYI("Substrait conversion not supported for Rel.");
 }

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -22,6 +22,23 @@
 
 namespace facebook::velox::substrait {
 
+struct SplitInfo {
+  /// The Partition index.
+  u_int32_t partitionIndex;
+
+  /// The file paths to be scanned.
+  std::vector<std::string> paths;
+
+  /// The file starts in the scan.
+  std::vector<u_int64_t> starts;
+
+  /// The lengths to be scanned.
+  std::vector<u_int64_t> lengths;
+
+  /// The file format of the files to be scanned.
+  dwio::common::FileFormat format;
+};
+
 /// This class is used to convert the Substrait plan into Velox plan.
 class SubstraitVeloxPlanConverter {
  public:
@@ -52,11 +69,7 @@ class SubstraitVeloxPlanConverter {
   /// Lengths: the lengths in byte to read from the items.
   std::shared_ptr<const core::PlanNode> toVeloxPlan(
       const ::substrait::ReadRel& sRead,
-      u_int32_t& index,
-      std::vector<std::string>& paths,
-      std::vector<u_int64_t>& starts,
-      std::vector<u_int64_t>& lengths,
-      int& fileFormat);
+      std::shared_ptr<SplitInfo>& splitInfo);
 
   /// Used to convert Substrait Rel into Velox PlanNode.
   std::shared_ptr<const core::PlanNode> toVeloxPlan(
@@ -80,29 +93,10 @@ class SubstraitVeloxPlanConverter {
     return functionMap_;
   }
 
-  /// Will return the index of Partition to be scanned.
-  u_int32_t getPartitionIndex() {
-    return partitionIndex_;
-  }
-
-  /// Will return the paths of the files to be scanned.
-  const std::vector<std::string>& getPaths() {
-    return paths_;
-  }
-
-  /// Will return the starts of the files to be scanned.
-  const std::vector<u_int64_t>& getStarts() {
-    return starts_;
-  }
-  
-  /// Will return the file format of the files to be scanned.
-  int getFileFormat() {
-    return fileFormat_;
-  }
-
-  /// Will return the lengths to be scanned for each file.
-  const std::vector<u_int64_t>& getLengths() {
-    return lengths_;
+  /// Return the splitInfo map used by this plan converter.
+  const std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>>&
+  splitInfos() const {
+    return splitInfoMap_;
   }
 
   /// Used to insert certain plan node as input. The plan node
@@ -353,27 +347,16 @@ class SubstraitVeloxPlanConverter {
       const std::shared_ptr<const core::PlanNode>& childNode,
       const core::AggregationNode::Step& aggStep);
 
-  /// The Partition index.
-  u_int32_t partitionIndex_;
-
-  /// The file paths to be scanned.
-  std::vector<std::string> paths_;
-
-  /// The file starts in the scan.
-  std::vector<u_int64_t> starts_;
-
-  /// The lengths to be scanned.
-  std::vector<u_int64_t> lengths_;
-  
-  // The file format of the files to be scanned.
-  int fileFormat_;
-
   /// The unique identification for each PlanNode.
   int planNodeId_ = 0;
 
   /// The map storing the relations between the function id and the function
   /// name. Will be constructed based on the Substrait representation.
   std::unordered_map<uint64_t, std::string> functionMap_;
+
+  /// The map storing the split stats for each PlanNode.
+  std::unordered_map<core::PlanNodeId, std::shared_ptr<SplitInfo>>
+      splitInfoMap_;
 
   /// The map storing the pre-built plan nodes which can be accessed through
   /// index. This map is only used when the computation of a Substrait plan

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -55,7 +55,8 @@ class SubstraitVeloxPlanConverter {
       u_int32_t& index,
       std::vector<std::string>& paths,
       std::vector<u_int64_t>& starts,
-      std::vector<u_int64_t>& lengths);
+      std::vector<u_int64_t>& lengths,
+      int& fileFormat);
 
   /// Used to convert Substrait Rel into Velox PlanNode.
   std::shared_ptr<const core::PlanNode> toVeloxPlan(
@@ -92,6 +93,11 @@ class SubstraitVeloxPlanConverter {
   /// Will return the starts of the files to be scanned.
   const std::vector<u_int64_t>& getStarts() {
     return starts_;
+  }
+  
+  /// Will return the file format of the files to be scanned.
+  int getFileFormat() {
+    return fileFormat_;
   }
 
   /// Will return the lengths to be scanned for each file.
@@ -358,6 +364,9 @@ class SubstraitVeloxPlanConverter {
 
   /// The lengths to be scanned.
   std::vector<u_int64_t> lengths_;
+  
+  // The file format of the files to be scanned.
+  int fileFormat_;
 
   /// The unique identification for each PlanNode.
   int planNodeId_ = 0;

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -299,12 +299,9 @@ bool SubstraitToVeloxPlanValidator::validate(
 bool SubstraitToVeloxPlanValidator::validate(
     const ::substrait::ReadRel& sRead) {
   try {
-    u_int32_t index;
-    std::vector<std::string> paths;
-    std::vector<u_int64_t> starts;
-    std::vector<u_int64_t> lengths;
+    auto splitInfo = std::make_shared<SplitInfo>();
 
-    planConverter_->toVeloxPlan(sRead, index, paths, starts, lengths);
+    planConverter_->toVeloxPlan(sRead, splitInfo);
   } catch (const VeloxException& err) {
     std::cout << "ReadRel validation failed due to:" << err.message()
               << std::endl;


### PR DESCRIPTION
Parsed and stored the file format in SubstraitVeloxPlanConverter and then created the corresponding Split according to the specified file format.