### PR TITLE
Filter out nulls by default

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -206,7 +206,7 @@ class SubstraitVeloxPlanConverter {
     bool isInitialized_ = false;
 
     // The null allow.
-    bool nullAllowed_ = true;
+    bool nullAllowed_ = false;
 
     // If true, left bound will be exclusive.
     std::vector<bool> lowerExclusives_;


### PR DESCRIPTION
To align with Spark's behavior, filter out nulls by default.