### PR TITLE
Parse options in SingularOrList correctly

### DIFF
--- a/velox/substrait/SubstraitToVeloxExpr.cpp
+++ b/velox/substrait/SubstraitToVeloxExpr.cpp
@@ -143,18 +143,50 @@ SubstraitVeloxExprConverter::toVeloxExpr(
       toVeloxType(typeName), std::move(params), veloxFunction);
 }
 
+std::shared_ptr<const core::ConstantTypedExpr>
+SubstraitVeloxExprConverter::literalsToConstantExpr(
+    const std::vector<::substrait::Expression::Literal>& literals) {
+  std::vector<variant> variants;
+  variants.reserve(literals.size());
+  VELOX_CHECK(literals.size() > 0, "List should have at least one item.");
+  std::optional<TypePtr> literalType = std::nullopt;
+  for (const auto& literal : literals) {
+    auto veloxVariant = toVeloxExpr(literal)->value();
+    if (!literalType.has_value()) {
+      literalType = veloxVariant.inferType();
+    }
+    variants.emplace_back(veloxVariant);
+  }
+  VELOX_CHECK(literalType.has_value(), "Type expected.");
+  // Create flat vector from the variants.
+  VectorPtr vector =
+      setVectorFromVariants(literalType.value(), variants, pool_);
+  // Create array vector from the flat vector.
+  ArrayVectorPtr arrayVector =
+      toArrayVector(literalType.value(), vector, pool_);
+  // Wrap the array vector into constant vector.
+  auto constantVector = BaseVector::wrapInConstant(1, 0, arrayVector);
+  return std::make_shared<const core::ConstantTypedExpr>(constantVector);
+}
+
 core::TypedExprPtr SubstraitVeloxExprConverter::toVeloxExpr(
     const ::substrait::Expression::SingularOrList& singularOrList,
     const RowTypePtr& inputType) {
+  VELOX_CHECK(
+      singularOrList.options_size() > 0, "At least one option is expected.");
+  auto options = singularOrList.options();
+  std::vector<::substrait::Expression::Literal> literals;
+  literals.reserve(options.size());
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    literals.emplace_back(option.literal());
+  }
+
   std::vector<std::shared_ptr<const core::ITypedExpr>> params;
-  // TODO: other options?
-  auto inLists = singularOrList.options();
-  VELOX_CHECK(inLists.size() > 0, "At least one option is needed.");
   params.reserve(2);
-  // first is the value, second is the list
+  // First param is the value, second param is the list.
   params.emplace_back(toVeloxExpr(singularOrList.value(), inputType));
-  // TODO: is this the correct way to use SingularOrList?
-  params.emplace_back(toVeloxExpr(inLists[0], inputType));
+  params.emplace_back(literalsToConstantExpr(literals));
   return std::make_shared<const core::CallTypedExpr>(
       BOOLEAN(), std::move(params), "in");
 }
@@ -184,35 +216,15 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     }
     case ::substrait::Expression_Literal::LiteralTypeCase::kString:
       return std::make_shared<core::ConstantTypedExpr>(
-          toTypedVariant(substraitLit)->veloxVariant);
+          variant(substraitLit.string()));
     case ::substrait::Expression_Literal::LiteralTypeCase::kList: {
-      // List is used in 'in' expression. Will wrap a constant
-      // vector with an array vector inside to create the constant expression.
-      std::vector<variant> variants;
-      variants.reserve(substraitLit.list().values().size());
-      VELOX_CHECK(
-          substraitLit.list().values().size() > 0,
-          "List should have at least one item.");
-      std::optional<TypePtr> literalType = std::nullopt;
+      // Literals in List are put in a constant vector.
+      std::vector<::substrait::Expression::Literal> literals;
+      literals.reserve(substraitLit.list().values().size());
       for (const auto& literal : substraitLit.list().values()) {
-        auto typedVariant = toTypedVariant(literal);
-        if (!literalType.has_value()) {
-          literalType = typedVariant->variantType;
-        }
-        variants.emplace_back(typedVariant->veloxVariant);
+        literals.emplace_back(literal);
       }
-      VELOX_CHECK(literalType.has_value(), "Type expected.");
-      // Create flat vector from the variants.
-      VectorPtr vector =
-          setVectorFromVariants(literalType.value(), variants, pool_);
-      // Create array vector from the flat vector.
-      ArrayVectorPtr arrayVector =
-          toArrayVector(literalType.value(), vector, pool_);
-      // Wrap the array vector into constant vector.
-      auto constantVector = BaseVector::wrapInConstant(1, 0, arrayVector);
-      auto constantExpr =
-          std::make_shared<core::ConstantTypedExpr>(constantVector);
-      return constantExpr;
+      return literalsToConstantExpr(literals);
     }
     default:
       VELOX_NYI(
@@ -294,36 +306,6 @@ SubstraitVeloxExprConverter::toVeloxExpr(
     default:
       VELOX_NYI(
           "Substrait conversion not supported for Expression '{}'", typeCase);
-  }
-}
-
-std::shared_ptr<SubstraitVeloxExprConverter::TypedVariant>
-SubstraitVeloxExprConverter::toTypedVariant(
-    const ::substrait::Expression::Literal& literal) {
-  auto typeCase = literal.literal_type_case();
-  switch (typeCase) {
-    case ::substrait::Expression_Literal::LiteralTypeCase::kBoolean: {
-      TypedVariant typedVariant = {variant(literal.boolean()), BOOLEAN()};
-      return std::make_shared<TypedVariant>(typedVariant);
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kI32: {
-      TypedVariant typedVariant = {variant(literal.i32()), INTEGER()};
-      return std::make_shared<TypedVariant>(typedVariant);
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kI64: {
-      TypedVariant typedVariant = {variant(literal.i64()), BIGINT()};
-      return std::make_shared<TypedVariant>(typedVariant);
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kFp64: {
-      TypedVariant typedVariant = {variant(literal.fp64()), DOUBLE()};
-      return std::make_shared<TypedVariant>(typedVariant);
-    }
-    case ::substrait::Expression_Literal::LiteralTypeCase::kString: {
-      TypedVariant typedVariant = {variant(literal.string()), VARCHAR()};
-      return std::make_shared<TypedVariant>(typedVariant);
-    }
-    default:
-      VELOX_NYI("ToVariant not supported for type case '{}'", typeCase);
   }
 }
 

--- a/velox/substrait/SubstraitToVeloxExpr.h
+++ b/velox/substrait/SubstraitToVeloxExpr.h
@@ -83,14 +83,15 @@ class SubstraitVeloxExprConverter {
       const ::substrait::Expression& substraitExpr,
       const RowTypePtr& inputType);
 
-  /// Get variant and its type from Substrait Literal.
-  std::shared_ptr<TypedVariant> toTypedVariant(
-      const ::substrait::Expression::Literal& literal);
-
   /// Convert Substrait IfThen into switch or if expression.
   std::shared_ptr<const core::ITypedExpr> toVeloxExpr(
       const ::substrait::Expression::IfThen& ifThenExpr,
       const RowTypePtr& inputType);
+
+  /// Wrap a constant vector from literals with an array vector inside to create
+  /// the constant expression.
+  std::shared_ptr<const core::ConstantTypedExpr> literalsToConstantExpr(
+      const std::vector<::substrait::Expression::Literal>& literals);
 
  private:
   /// Memory pool.

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -1588,15 +1588,13 @@ bool SubstraitVeloxPlanConverter::canPushdownSingularOrList(
     const ::substrait::Expression_SingularOrList& singularOrList,
     bool disableIntLike) {
   VELOX_CHECK(
-      singularOrList.options_size() == 1,
-      "Only one options list is expected in SingularOrList expression.");
+      singularOrList.options_size() > 0, "At least one option is expected.");
   // Check whether the value is field.
   bool hasField = singularOrList.value().has_selection();
-  // TODO: improve the logic here.
-  auto literals = singularOrList.options()[0].literal().list().values();
-  std::vector<std::string> types;
-  for (auto& literal : literals) {
-    auto type = literal.literal_type_case();
+  auto options = singularOrList.options();
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
+    auto type = option.literal().literal_type_case();
     // Only BigintValues and BytesValues are supported.
     if (type != ::substrait::Expression_Literal::LiteralTypeCase::kI32 &&
         type != ::substrait::Expression_Literal::LiteralTypeCase::kI64 &&
@@ -1633,23 +1631,19 @@ uint32_t SubstraitVeloxPlanConverter::getColumnIndexFromSingularOrList(
 void SubstraitVeloxPlanConverter::setSingularListValues(
     const ::substrait::Expression_SingularOrList& singularOrList,
     std::unordered_map<uint32_t, std::shared_ptr<FilterInfo>>& colInfoMap) {
+  VELOX_CHECK(
+      singularOrList.options_size() > 0, "At least one option is expected.");
   // Get the column index.
   uint32_t colIdx = getColumnIndexFromSingularOrList(singularOrList);
 
   // Get the value list.
+  auto options = singularOrList.options();
   std::vector<variant> variants;
-  VELOX_CHECK(
-      singularOrList.options_size() == 1,
-      "Options list size 1 expected in SingularOrList expression.");
-  auto option = singularOrList.options()[0];
-  VELOX_CHECK(
-      option.has_literal(),
-      "Options list has literal expected in SingularOrList expression.");
-  auto valueList = option.literal().list();
-  variants.reserve(valueList.values().size());
-  for (const auto& literal : valueList.values()) {
+  variants.reserve(options.size());
+  for (const auto& option : options) {
+    VELOX_CHECK(option.has_literal(), "Literal is expected as option.");
     variants.emplace_back(
-        exprConverter_->toTypedVariant(literal)->veloxVariant);
+        exprConverter_->toVeloxExpr(option.literal())->value());
   }
   // Set the value list to filter info.
   colInfoMap[colIdx]->setValues(variants);


### PR DESCRIPTION
Options in SingularOrList is no longer a single list, instead, each option is a literal. This PR parses the options correctly.