### PR TITLE
Add -fPIC to PB build

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -87,7 +87,9 @@ function install_protobuf {
   wget https://github.com/protocolbuffers/protobuf/releases/download/v21.4/protobuf-all-21.4.tar.gz
   tar -xzf protobuf-all-21.4.tar.gz
   cd protobuf-21.4
-  ./configure --prefix=/usr
+  ./configure \
+      CXXFLAGS="-fPIC"
+      --prefix=/usr
   make "-j$(nproc)"
   sudo make install
   sudo ldconfig

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -88,7 +88,7 @@ function install_protobuf {
   tar -xzf protobuf-all-21.4.tar.gz
   cd protobuf-21.4
   ./configure \
-      CXXFLAGS="-fPIC"
+      CXXFLAGS="-fPIC" \
       --prefix=/usr
   make "-j$(nproc)"
   sudo make install


### PR DESCRIPTION
Or

```
`_ZN6google8protobuf8internal15ThreadSafeArena13thread_cache_E' can not be used when making a shared object
```

Will take place when doing a clean build of Gluten