### PR TITLE
Add support for regular anti join (#2906)

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -984,6 +984,7 @@ enum class JoinType {
   kLeftSemi,
   kRightSemi,
   kNullAwareAnti,
+  kAnti,
 };
 
 inline const char* joinTypeName(JoinType joinType) {
@@ -1002,6 +1003,8 @@ inline const char* joinTypeName(JoinType joinType) {
       return "RIGHT SEMI";
     case JoinType::kNullAwareAnti:
       return "NULL-AWARE ANTI";
+    case JoinType::kAnti:
+      return "ANTI";
   }
   VELOX_UNREACHABLE();
 }
@@ -1032,6 +1035,14 @@ inline bool isRightSemiJoin(JoinType joinType) {
 
 inline bool isNullAwareAntiJoin(JoinType joinType) {
   return joinType == JoinType::kNullAwareAnti;
+}
+
+inline bool isAntiJoin(JoinType joinType) {
+  return joinType == JoinType::kAnti;
+}
+
+inline bool isAntiJoins(JoinType joinType) {
+  return isAntiJoin(joinType) || isNullAwareAntiJoin(joinType);
 }
 
 /// Abstract class representing inner/outer/semi/anti joins. Used as a base
@@ -1086,6 +1097,10 @@ class AbstractJoinNode : public PlanNode {
 
   bool isNullAwareAntiJoin() const {
     return joinType_ == JoinType::kNullAwareAnti;
+  }
+
+  bool isAntiJoin() const {
+    return joinType_ == JoinType::kAnti;
   }
 
   const std::vector<FieldAccessTypedExprPtr>& leftKeys() const {

--- a/velox/docs/develop/anti-join.rst
+++ b/velox/docs/develop/anti-join.rst
@@ -8,9 +8,8 @@ in the presence of NULLs in the outer query or subquery. NOT IN semantics are
 implemented by the null aware anti join. NOT EXISTS semantics are implemented
 by the regular anti join.
 
-Currently, Velox provides only null aware anti join via the JoinType::kAnti.
-Regular anti join is not available. We will rename kAnti to kNullAwareAnti for
-clarity and introduce a new kAnti join type for the regular anti join.
+Velox provides regular anti join via ``JoinType::kAnti`` and null-aware anti
+join via ``JoinType::kNullAwareAnti``.
 
 This article explains the differences in semantics between NOT IN and NOT EXISTS
 queries and discusses the implementation of these in the null aware and regular
@@ -566,16 +565,3 @@ For the left-side row with no nulls in the join key, the join needs to collect
 the matches from the right side. If there are no matches, the row is included
 in the results. If there are matches, the extra filter needs to be evaluated.
 If the filter comes out empty, the row is included in the results.
-
-Summary
--------
-
-Velox currently provides null aware anti join via the JoinType::kAnti. Regular
-anti join is not available. There is also a bug in filter processing where the
-join always returns empty results if there is a build side row with null in the
-join key.
-
-To provide full support for efficient execution of NOT IN and NOT EXISTS
-queries, we will rename kAnti to kNullAwareAnti and introduce a new kAnti join
-type for the regular anti join. We will also fix the bug in null aware anti
-join with filter.

--- a/velox/exec/HashBuild.h
+++ b/velox/exec/HashBuild.h
@@ -210,17 +210,17 @@ class HashBuild final : public Operator {
   // Invoked to process data from spill input reader on restoring.
   void processSpillInput();
 
-  // Set up for null-aware anti-join with filter processing.
-  void setupFilterForNullAwareAntiJoin(
+  // Set up for null-aware and regular anti-join with filter processing.
+  void setupFilterForAntiJoins(
       const folly::F14FastMap<column_index_t, column_index_t>& keyChannelMap);
 
-  // Invoked when preparing for null-aware anti join with null-propagating
-  // filter. The function deselects the input rows which have any null in the
-  // filter input columns. This is an optimization for null-aware anti join
-  // processing at the probe side as any probe matches with the deselected rows
-  // can't pass the null-propagating filter and will be added to the joined
-  // output.
-  void removeInputRowsForNullAwareAntiJoinFilter();
+  // Invoked when preparing for null-aware and regular anti join with
+  // null-propagating filter. The function deselects the input rows which have
+  // any null in the filter input columns. This is an optimization for
+  // null-aware and regular anti join processing at the probe side as any probe
+  // matches with the deselected rows can't pass the null-propagating filter and
+  // will be added to the joined output.
+  void removeInputRowsForAntiJoinFilter();
 
   void addRuntimeStats();
 

--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -95,7 +95,7 @@ class SubstraitParser {
   std::unordered_map<std::string, std::string> substraitVeloxFunctionMap_ = {
       {"is_not_null", "isnotnull"}, /*Spark functions.*/
       {"is_null", "isnull"},
-      {"equal", "equalto"}, 
+      {"equal", "equalto"},
       {"lt", "lessthan"},
       {"lte", "lessthanorequal"},
       {"gt", "greaterthan"},

--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -156,9 +156,26 @@ core::PlanNodePtr SubstraitVeloxPlanConverter::toVeloxPlan(
     case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_RIGHT_SEMI:
       joinType = core::JoinType::kRightSemi;
       break;
-    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_ANTI:
-      joinType = core::JoinType::kNullAwareAnti;
+    case ::substrait::JoinRel_JoinType::JoinRel_JoinType_JOIN_TYPE_ANTI: {
+      // Determine the anti join type based on extracted information.
+      bool isNullAwareAntiJoin = false;
+      if (sJoin.has_advanced_extension() &&
+          sJoin.advanced_extension().has_optimization()) {
+        std::string msg = sJoin.advanced_extension().optimization().value();
+        std::string nullAwareKey = "isNullAwareAntiJoin=";
+        std::size_t pos = msg.find(nullAwareKey);
+        if ((pos != std::string::npos) &&
+            (msg.substr(pos + nullAwareKey.size(), 1) == "1")) {
+          isNullAwareAntiJoin = true;
+        }
+      }
+      if (isNullAwareAntiJoin) {
+        joinType = core::JoinType::kNullAwareAnti;
+      } else {
+        joinType = core::JoinType::kAnti;
+      }
       break;
+    }
     default:
       VELOX_NYI("Unsupported Join type: {}", sJoin.type());
   }


### PR DESCRIPTION
Summary:
Pull Request resolved: https://github.com/facebookincubator/velox/pull/2906

Regular anti join is different from null-aware anti join in that:
1. NULL in build side does not affect the result.  They won't be joined and won't participate in filtering.
2. NULL in probe side will always be added to the output.

Fix https://github.com/facebookincubator/velox/issues/2438

Reviewed By: xiaoxmeng, mbasmanova

Differential Revision: D40558788

fbshipit-source-id: 4f249987925bfdec9cc0cef9085ce965d6e27a5a