### PR TITLE
[Tmp Fix] Set the multiplier before using normalized key mode

### DIFF
--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1291,10 +1291,12 @@ void HashTable<ignoreNullKeys>::decideHashMode(int32_t numNew) {
   if (bestWithReserve != VectorHasher::kRangeTooLarge) {
     enableRangeWhereCan(rangeSizes, distinctSizes, useRange);
     setHasherMode(hashers_, useRange, rangeSizes, distinctSizes);
+    setHashMode(HashMode::kNormalizedKey, numNew);
   } else {
     clearUseRange(useRange);
+    setHasherMode(hashers_, useRange, rangeSizes, distinctSizes);
+    setHashMode(HashMode::kNormalizedKey, numNew);
   }
-  setHashMode(HashMode::kNormalizedKey, numNew);
 }
 
 template <bool ignoreNullKeys>

--- a/velox/exec/HashTable.cpp
+++ b/velox/exec/HashTable.cpp
@@ -1290,13 +1290,11 @@ void HashTable<ignoreNullKeys>::decideHashMode(int32_t numNew) {
   // The key concatenation fits in 64 bits.
   if (bestWithReserve != VectorHasher::kRangeTooLarge) {
     enableRangeWhereCan(rangeSizes, distinctSizes, useRange);
-    setHasherMode(hashers_, useRange, rangeSizes, distinctSizes);
-    setHashMode(HashMode::kNormalizedKey, numNew);
   } else {
     clearUseRange(useRange);
-    setHasherMode(hashers_, useRange, rangeSizes, distinctSizes);
-    setHashMode(HashMode::kNormalizedKey, numNew);
   }
+  setHasherMode(hashers_, useRange, rangeSizes, distinctSizes);
+  setHashMode(HashMode::kNormalizedKey, numNew);
 }
 
 template <bool ignoreNullKeys>


### PR DESCRIPTION
To fix the incorrect hash id calculation, set the multiplier before using normalized key mode.