### PR TITLE
Fix the name of bitwise

### DIFF
--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -109,6 +109,8 @@ class SubstraitParser {
       {"strpos", "instr"},
       {"ends_with", "endswith"},
       {"starts_with", "startswith"},
+      {"BitwiseAnd", "bitwise_and"},
+      {"BitwiseOr", "bitwise_or"},
       {"modulus", "mod"} /*Presto functions.*/};
 };
 


### PR DESCRIPTION
The name of bitwise should be aligned with Substrait after it being added into yaml files.