### PR TITLE
Fix half up in round

### DIFF
--- a/velox/functions/prestosql/ArithmeticImpl.h
+++ b/velox/functions/prestosql/ArithmeticImpl.h
@@ -43,10 +43,11 @@ round(const TNum& number, const TDecimals& decimals = 0) {
   }
 
   double factor = std::pow(10, decimals);
+  double variance = 0.1;
   if (number < 0) {
-    return (std::round(number * factor * -1) / factor) * -1;
+    return (std::round(std::nextafter(number, number - variance) * factor * -1) / factor) * -1;
   }
-  return std::round(number * factor) / factor;
+  return std::round(std::nextafter(number, number + variance) * factor) / factor;
 }
 
 // This is used by Velox for floating points plus.


### PR DESCRIPTION
Previously, rounding for `1.0249999999999999` could be `1.024` due to the division is by truncate. With this change, number like `1.0249999999999999` will become `1.0250000000000001`, and `-1.0249999999999999` will become `-1.0250000000000001`, which makes the number can be correctly rounded to `1.025` or `-1.025`.