### PR TITLE
Revert a commit: Fix the name of bitwise (#93)

### DIFF
--- a/velox/substrait/SubstraitParser.h
+++ b/velox/substrait/SubstraitParser.h
@@ -123,8 +123,6 @@ class SubstraitParser {
       {"strpos", "instr"},
       {"ends_with", "endswith"},
       {"starts_with", "startswith"},
-      {"BitwiseAnd", "bitwise_and"},
-      {"BitwiseOr", "bitwise_or"},
       {"modulus", "mod"} /*Presto functions.*/};
   // The map is uesd for mapping substrait type.
   // Key: type in function name.


### PR DESCRIPTION
This reverts commit bb2d4cbb6e444f2444437063b497bbccc579280d, which is unnecessary after we use a consistent name as substrait's.