### PR TITLE
Fix VeloxRuntimeError when reading parquet file with only meta data

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -56,7 +56,7 @@ void ReaderBase::loadFileMetaData() {
 
   uint32_t footerLength =
       *(reinterpret_cast<const uint32_t*>(copy.data() + readSize - 8));
-  VELOX_CHECK_LT(footerLength + 12, fileLength_);
+  VELOX_CHECK_LE(footerLength + 12, fileLength_);
   int32_t footerOffsetInBuffer = readSize - 8 - footerLength;
   if (footerLength > readSize - 8) {
     footerOffsetInBuffer = 0;


### PR DESCRIPTION
Issue is exposed from https://github.com/oap-project/gluten/issues/770