### PR TITLE
Fix the result mismatch for right expression

### DIFF
--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -255,6 +255,13 @@ struct SubstrFunction {
     if (start < 0) {
       start = numCharacters + start + 1;
     }
+    
+    // Following vanilla spark semantics. When the start is 0 after adjusing start,
+    // Keep the origin input. 
+    if (start <= 0) {
+      start = 1;
+      length = numCharacters;
+    }
 
     // Following Presto semantics
     if (start <= 0 || start > numCharacters || length <= 0) {


### PR DESCRIPTION
For `right("ab", 3)` expression, vanilla spark will convert the expression to substring("ab", -3). When offload to velox, the start index will be negative. And then the result will be empty, which is not same with vanilla spark "ab". This PR is aim to keep the result same with vanilla spark.