### PR TITLE
Fix compilation

### DIFF
--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -88,7 +88,7 @@ function install_conda {
   mkdir -p conda && cd conda
   wget https://repo.anaconda.com/miniconda/Miniconda3-latest-Linux-x86_64.sh
   MINICONDA_PATH=/opt/miniconda-for-velox
-  bash Miniconda3-latest-Linux-x86_64.sh -b -p $MINICONDA_PATH
+  bash Miniconda3-latest-Linux-x86_64.sh -b -u $MINICONDA_PATH
 }
 
 function install_velox_deps {


### PR DESCRIPTION
Fixed below compilation error.

```
bash Miniconda3-latest-Linux-x86_64.sh -b -p /opt/miniconda-for-velox
ERROR: File or directory already exists: '/opt/miniconda-for-velox'
If you want to update an existing installation, use the -u option.
```