### PR TITLE
Enables getting value from date variant with integer type

### DIFF
--- a/velox/type/Variant.h
+++ b/velox/type/Variant.h
@@ -542,6 +542,10 @@ class variant {
   }
 
   void checkIsKind(TypeKind kind) const {
+    // Integer is compatible for getting the value from a date variant.
+    if (kind_ == TypeKind::DATE && kind == TypeKind::INTEGER) {
+      return;
+    }
     if (kind_ != kind) {
       // Error path outlined to encourage inlining of the branch.
       throwCheckIsKindError(kind);


### PR DESCRIPTION
Fixed the data type check when getting value from a date variant with integer type.