### PR TITLE
Fix wrong batch scan push down filter expression when the expression is 123 < q1

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlan.cpp
+++ b/velox/substrait/SubstraitToVeloxPlan.cpp
@@ -1608,10 +1608,12 @@ void SubstraitVeloxPlanConverter::setFilterMap(
   }
 
   std::unordered_map<std::string, std::string> functionRevertMap = {
-      {"lt", "gt"}, {"gt", "lt"}, {"gte", "lte"}, {"lte", "gte"}};
+      {sLt, sGt}, {sGt, sLt}, {sGte, sLte}, {sLte, sGte}};
 
-  // Handle 123 < q1 case
-  if (typeCases[0] == "kLiteral") {
+  // Handle "123 < q1" type expression case
+  if (typeCases.size() > 1 &&
+      (typeCases[0] == "kLiteral" && typeCases[1] == "kSelection") &&
+      functionRevertMap.find(functionName) != functionRevertMap.end()) {
     // change the function name: lt => gt, gt => lt, gte => lte, lte => gte
     functionName = functionRevertMap[functionName];
   }


### PR DESCRIPTION
When the expression is `123 < q1`, Velox will convert it as `q1 < 123` when calculating the filter info. This PR checks if the first argument is a constant, and if so, reverses the function name `(lt => gt, gt => lt, gte => lte, lte => gt)`.