### PR TITLE
change dense rank return type to integer

### DIFF
--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -113,7 +113,7 @@ void registerRank(const std::string& name) {
   registerRankInternal<RankType::kRank, int32_t>(name, "integer");
 }
 void registerDenseRank(const std::string& name) {
-  registerRankInternal<RankType::kDenseRank, int64_t>(name, "bigint");
+  registerRankInternal<RankType::kDenseRank, int32_t>(name, "integer");
 }
 void registerPercentRank(const std::string& name) {
   registerRankInternal<RankType::kPercentRank, double>(name, "double");


### PR DESCRIPTION
@JkSelf, I see that you change rank return type to integer to be consistent with the return type of spark's rank. I also need to modify when I adapt the dense rank.