### PR TITLE
Port upstream patch to fix parquet reader issue on long min/max string data

### DIFF
--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -50,6 +50,21 @@ class PageReader {
     type_->makeLevelInfo(leafInfo_);
   }
 
+  // This PageReader constructor is for unit test only.
+  PageReader(
+      std::unique_ptr<dwio::common::SeekableInputStream> stream,
+      memory::MemoryPool& pool,
+      thrift::CompressionCodec::type codec,
+      int64_t chunkSize)
+      : pool_(pool),
+        inputStream_(std::move(stream)),
+        maxRepeat_(0),
+        maxDefine_(1),
+        isTopLevel_(maxRepeat_ == 0 && maxDefine_ <= 1),
+        codec_(codec),
+        chunkSize_(chunkSize),
+        nullConcatenation_(pool_) {}
+
   /// Advances 'numRows' top level rows.
   void skip(int64_t numRows);
 
@@ -110,6 +125,10 @@ class PageReader {
     return {repDefBegin_, repDefEnd_};
   }
 
+  // Parses the PageHeader at 'inputStream_', and move the bufferStart_ and
+  // bufferEnd_ to the corresponding positions.
+  thrift::PageHeader readPageHeader();
+
  private:
   // Indicates that we only want the repdefs for the next page. Used when
   // prereading repdefs with seekToPage.
@@ -161,10 +180,6 @@ class PageReader {
   // next page.
   void updateRowInfoAfterPageSkipped();
 
-  // Parses the PageHeader at 'inputStream_'. Will not read more than
-  // 'remainingBytes' since there could be less data left in the
-  // ColumnChunk than the full header size.
-  thrift::PageHeader readPageHeader(int64_t remainingSize);
   void prepareDataPageV1(const thrift::PageHeader& pageHeader, int64_t row);
   void prepareDataPageV2(const thrift::PageHeader& pageHeader, int64_t row);
   void prepareDictionary(const thrift::PageHeader& pageHeader);

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -75,11 +75,12 @@ void ReaderBase::loadFileMetaData() {
         missingLength, stream.get(), copy.data(), bufferStart, bufferEnd);
   }
 
-  auto thriftTransport = std::make_shared<thrift::ThriftBufferedTransport>(
-      copy.data() + footerOffsetInBuffer, footerLength);
-  auto thriftProtocol =
-      std::make_unique<apache::thrift::protocol::TCompactProtocolT<
-          thrift::ThriftBufferedTransport>>(thriftTransport);
+  std::shared_ptr<thrift::ThriftTransport> thriftTransport =
+      std::make_shared<thrift::ThriftBufferedTransport>(
+          copy.data() + footerOffsetInBuffer, footerLength);
+  auto thriftProtocol = std::make_unique<
+      apache::thrift::protocol::TCompactProtocolT<thrift::ThriftTransport>>(
+      thriftTransport);
   fileMetaData_ = std::make_unique<thrift::FileMetaData>();
   fileMetaData_->read(thriftProtocol.get());
 }

--- a/velox/dwio/parquet/tests/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/CMakeLists.txt
@@ -24,6 +24,7 @@ set(TEST_LINK_LIBS
 
 add_subdirectory(duckdb_reader)
 add_subdirectory(reader)
+add_subdirectory(thrift)
 
 add_executable(velox_dwio_parquet_tpch_test ParquetTpchTest.cpp)
 add_test(

--- a/velox/dwio/parquet/tests/thrift/CMakeLists.txt
+++ b/velox/dwio/parquet/tests/thrift/CMakeLists.txt
@@ -1,0 +1,19 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+add_executable(velox_dwio_parquet_thrift_test ThriftTransportTest.cpp)
+
+add_test(velox_dwio_parquet_thrift_test velox_dwio_parquet_thrift_test)
+target_link_libraries(velox_dwio_parquet_thrift_test arrow thrift
+                      ${VELOX_LINK_LIBS} gtest gtest_main)

--- a/velox/dwio/parquet/tests/thrift/ThriftTransportTest.cpp
+++ b/velox/dwio/parquet/tests/thrift/ThriftTransportTest.cpp
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "velox/dwio/parquet/thrift/ThriftTransport.h"
+#include <folly/init/Init.h>
+#include <gtest/gtest.h>
+
+using namespace facebook::velox;
+using namespace facebook::velox::dwio::common;
+using namespace facebook::velox::parquet::thrift;
+
+class ThriftTransportTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    input_.resize(bufferSize_);
+    output_.resize(bufferSize_);
+    for (size_t i = 0; i < input_.size(); ++i) {
+      input_[i] = static_cast<uint8_t>(i);
+    }
+  }
+
+  void prepareThriftStreamingTransport() {
+    inputStream_ = std::make_shared<SeekableArrayInputStream>(
+        input_.data(), input_.size(), 20);
+    int32_t batchSize_;
+    const void* bufferPointer;
+    if (!inputStream_->Next(&bufferPointer, &batchSize_)) {
+      VELOX_CHECK(false, "Reading past end");
+    }
+    bufferStart_ = static_cast<const char*>(bufferPointer);
+    bufferEnd_ = bufferStart_ + batchSize_;
+    transport_ = std::make_shared<ThriftStreamingTransport>(
+        inputStream_.get(), bufferStart_, bufferEnd_);
+  }
+
+  void prepareThriftBufferedTransport() {
+    transport_ =
+        std::make_shared<ThriftBufferedTransport>(input_.data(), bufferSize_);
+  }
+
+  static constexpr uint32_t bufferSize_ = 200;
+  static constexpr uint32_t batchSize_ = 20;
+  std::vector<uint8_t> input_;
+  std::vector<uint8_t> output_;
+  const char* FOLLY_NULLABLE bufferStart_{nullptr};
+  const char* FOLLY_NULLABLE bufferEnd_{nullptr};
+  std::shared_ptr<SeekableInputStream> inputStream_;
+  std::shared_ptr<ThriftTransport> transport_;
+};
+
+TEST_F(ThriftTransportTest, streaming) {
+  prepareThriftStreamingTransport();
+  transport_->read(output_.data(), 10);
+  transport_->read(output_.data() + 10, 50);
+  transport_->read(output_.data() + 60, 140);
+
+  for (size_t i = 0; i < input_.size(); ++i) {
+    VELOX_CHECK_EQ(input_[i], output_[i]);
+  }
+}
+
+TEST_F(ThriftTransportTest, streamingOutOfBoundry) {
+  prepareThriftStreamingTransport();
+  transport_->read(output_.data(), 10);
+  transport_->read(output_.data() + 10, 50);
+  transport_->read(output_.data() + 60, 140);
+
+  // The whole inputStream_ is consumed.
+  EXPECT_ANY_THROW(transport_->read(output_.data() + bufferSize_, 1));
+}
+
+TEST_F(ThriftTransportTest, buffered) {
+  prepareThriftBufferedTransport();
+  transport_->read(output_.data(), 10);
+  transport_->read(output_.data() + 10, 50);
+  transport_->read(output_.data() + 60, 140);
+
+  for (size_t i = 0; i < input_.size(); ++i) {
+    VELOX_CHECK_EQ(input_[i], output_[i]);
+  }
+}
+
+TEST_F(ThriftTransportTest, bufferedOutOfBoundry) {
+  prepareThriftStreamingTransport();
+  transport_->read(output_.data(), 10);
+  transport_->read(output_.data() + 10, 50);
+  transport_->read(output_.data() + 60, 140);
+
+  // The whole inputStream_ is consumed.
+  EXPECT_ANY_THROW(transport_->read(output_.data() + bufferSize_, 1));
+}
+
+// Define main so that gflags get processed.
+int main(int argc, char** argv) {
+  testing::InitGoogleTest(&argc, argv);
+  folly::init(&argc, &argv, false);
+  return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
There are two PRs in the velox community to fix such issue: 4160 (merged) &  4108 (pending). We are porting these two patches here with binary file (test purpose) excluded.