### PR TITLE
Check a fallback case in validation: using literal partition key in window function

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -321,7 +321,15 @@ bool SubstraitToVeloxPlanValidator::validate(
   expressions.reserve(groupByExprs.size());
   try {
     for (const auto& expr : groupByExprs) {
-      expressions.emplace_back(exprConverter_->toVeloxExpr(expr, rowType));
+      auto expression = exprConverter_->toVeloxExpr(expr, rowType);
+      auto expr_field =
+        dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+      if (expr_field == nullptr) {
+        std::cout << "Only field is supported for partition key in Window Operator!" << std::endl;
+        return false;
+      } else {
+        expressions.emplace_back(expression);
+      }
     }
     // Try to compile the expressions. If there is any unregistred funciton or
     // mismatched type, exception will be thrown.

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -323,9 +323,11 @@ bool SubstraitToVeloxPlanValidator::validate(
     for (const auto& expr : groupByExprs) {
       auto expression = exprConverter_->toVeloxExpr(expr, rowType);
       auto expr_field =
-        dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
+          dynamic_cast<const core::FieldAccessTypedExpr*>(expression.get());
       if (expr_field == nullptr) {
-        std::cout << "Only field is supported for partition key in Window Operator!" << std::endl;
+        std::cout
+            << "Only field is supported for partition key in Window Operator!"
+            << std::endl;
         return false;
       } else {
         expressions.emplace_back(expression);


### PR DESCRIPTION
Currently, it is not allowed in Velox to use literal as partition key in window function, which is a rare use case. So we are blocking this case in validator to make fallback possible for this case.