### PR TITLE
fix ut compile failed from gluten

### DIFF
--- a/velox/common/strings/ByteStream.h
+++ b/velox/common/strings/ByteStream.h
@@ -171,7 +171,9 @@ class ByteSinkBuffer : public std::basic_streambuf<char> {
   }
 
  private:
-  int_type flush();
+  int_type flush() {
+    return 0;
+  }
 
   char putArea_[kPutAreaSize];
   ByteSink& sink_;

--- a/velox/vector/FlatVector-inl.h
+++ b/velox/vector/FlatVector-inl.h
@@ -100,7 +100,7 @@ std::unique_ptr<SimpleVector<uint64_t>> FlatVector<T>::hashAll() const {
 
   // overwrite the null hash values
   if (!BaseVector::nullCount_.has_value() ||
-      BaseVector::nullCount_.value() > 0) {
+      BaseVector::getNullCount().value() > 0) {
     for (size_t i = 0; i < BaseVector::length_; ++i) {
       if (bits::isBitNull(BaseVector::rawNulls_, i)) {
         hashData[i] = BaseVector::kNullHash;


### PR DESCRIPTION
While compile gluten with `BUILD_TESTS=ON` and `GCC12.1.0`, we got two errors.

Error1, the function flush do not implemented.
```
/home/opt/compiler/gcc-12/bin/../lib/gcc/x86_64-pc-linux-gnu/12.1.0/../../../../x86_64-pc-linux-gnu/bin/ld: 
../../releases/libvelox.so: undefined reference to `facebook::strings::ByteSinkBuffer::flush()
```

Error2, seems GCC12 is not smart enough.
```
In file included from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector.h:514,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/tests/utils/VectorTestBase.h:21,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/velox/tests/ArrowToVeloxTest.cc:22:
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h: In instantiation of ‘std::unique_ptr<facebook::velox::SimpleVector<long unsigned int> > facebook::velox::FlatVector<T>::hashAll() const [with T = facebook::velox::IntervalDayTime]’:
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h:80:41:   required from here
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h:103:35: error: passing ‘const std::optional<int>’ as ‘this’ argument discards qualifiers [-fpermissive]
  103 |       BaseVector::nullCount_.value() > 0) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
In file included from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/build/releases/include/arrow/util/iterator.h:23,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/build/releases/include/arrow/record_batch.h:28,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/build/releases/include/arrow/ipc/reader.h:32,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/core/jni/JniCommon.h:20,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/core/jni/JniErrors.h:22,
                 from /ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/velox/tests/ArrowToVeloxTest.cc:18:
/home/opt/compiler/gcc-12/include/c++/12.1.0/optional:999:7: note:   in call to ‘constexpr _Tp& std::optional<_Tp>::value() & [with _Tp = int]’
  999 |       value()&
      |       ^~~~~
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h: In instantiation of ‘std::unique_ptr<facebook::velox::SimpleVector<long unsigned int> > facebook::velox::FlatVector<T>::hashAll() const [with T = facebook::velox::Date]’:
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h:80:41:   required from here
/ssd1/zhuxiaoli01/codes/baidu/third-party/gluten/cpp/../ep/build-velox/build/velox_ep/velox/vector/FlatVector-inl.h:103:35: error: passing ‘const std::optional<int>’ as ‘this’ argument discards qualifiers [-fpermissive]
  103 |       BaseVector::nullCount_.value() > 0) {
      |       ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^~
/home/opt/compiler/gcc-12/include/c++/12.1.0/optional:999:7: note:   in call to ‘constexpr _Tp& std::optional<_Tp>::value() & [with _Tp = int]’
  999 |       value()&
      |       ^~~~~
```
