### PR TITLE
Fix file offset being zero

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -551,7 +551,11 @@ void ParquetRowReader::filterRowGroups() {
     auto fileOffset = rowGroups_[i].__isset.file_offset
         ? rowGroups_[i].file_offset
         : rowGroups_[i].columns[0].file_offset;
-    VELOX_CHECK_GT(fileOffset, 0);
+    VELOX_CHECK_GE(fileOffset, 0);
+    if (fileOffset == 0) {
+      rowGroupIds_.push_back(i);
+      continue;
+    }
     auto rowGroupInRange =
         (fileOffset >= options_.getOffset() &&
          fileOffset < options_.getLimit());


### PR DESCRIPTION
Do not skip a row group when offset is zero.