### PR TITLE
Support parquet write  in gluten

### DIFF
--- a/velox/connectors/Connector.h
+++ b/velox/connectors/Connector.h
@@ -329,7 +329,8 @@ class Connector {
       RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx,
-      CommitStrategy commitStrategy) = 0;
+      CommitStrategy commitStrategy,
+      std::string format = "dwrf") = 0;
 
   // Returns a ScanTracker for 'id'. 'id' uniquely identifies the
   // tracker and different threads will share the same

--- a/velox/connectors/fuzzer/FuzzerConnector.h
+++ b/velox/connectors/fuzzer/FuzzerConnector.h
@@ -123,7 +123,8 @@ class FuzzerConnector final : public Connector {
       std::shared_ptr<
           ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
-      CommitStrategy /*commitStrategy*/) override final {
+      CommitStrategy /*commitStrategy*/,
+      std::string format = "dwrf") override final {
     VELOX_NYI("FuzzerConnector does not support data sink.");
   }
 };

--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -18,7 +18,7 @@ add_library(
   FileHandle.cpp PartitionIdGenerator.cpp)
 
 target_link_libraries(velox_hive_connector velox_connector velox_dwio_common_exception
-                      velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file)
+                      velox_dwio_dwrf_reader velox_dwio_dwrf_writer velox_file velox_dwio_parquet_writer)
 
 add_library(velox_hive_partition_function HivePartitionFunction.cpp)
 

--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -49,7 +49,7 @@ HiveConfig::insertExistingPartitionsBehavior(const Config* config) {
 
 // static
 uint32_t HiveConfig::maxPartitionsPerWriters(const Config* config) {
-  return config->get<uint32_t>(kMaxPartitionsPerWriters, 100);
+  return config->get<uint32_t>(kMaxPartitionsPerWriters, 300);
 }
 
 bool HiveConfig::isCaseSensitive(const Config* config) {

--- a/velox/connectors/hive/HiveConnector.h
+++ b/velox/connectors/hive/HiveConnector.h
@@ -16,6 +16,7 @@
 #pragma once
 
 #include "velox/connectors/hive/FileHandle.h"
+#include "velox/connectors/hive/HiveConfig.h"
 #include "velox/connectors/hive/HiveConnectorSplit.h"
 #include "velox/connectors/hive/HiveDataSink.h"
 #include "velox/dwio/common/CachedBufferedInput.h"
@@ -27,7 +28,6 @@
 #include "velox/expression/Expr.h"
 #include "velox/type/Filter.h"
 #include "velox/type/Subfield.h"
-#include "velox/connectors/hive/HiveConfig.h"
 
 namespace facebook::velox::connector::hive {
 
@@ -273,13 +273,14 @@ class HiveConnector final : public Connector {
       RowTypePtr inputType,
       std::shared_ptr<ConnectorInsertTableHandle> connectorInsertTableHandle,
       ConnectorQueryCtx* connectorQueryCtx,
-      CommitStrategy commitStrategy) override final {
+      CommitStrategy commitStrategy,
+      std::string format = "dwrf") override final {
     auto hiveInsertHandle = std::dynamic_pointer_cast<HiveInsertTableHandle>(
         connectorInsertTableHandle);
     VELOX_CHECK_NOT_NULL(
         hiveInsertHandle, "Hive connector expecting hive write handle!");
     return std::make_shared<HiveDataSink>(
-        inputType, hiveInsertHandle, connectorQueryCtx, commitStrategy);
+        inputType, hiveInsertHandle, connectorQueryCtx, commitStrategy, format);
   }
 
   folly::Executor* FOLLY_NULLABLE executor() const override {

--- a/velox/connectors/hive/HiveDataSink.h
+++ b/velox/connectors/hive/HiveDataSink.h
@@ -17,6 +17,7 @@
 
 #include "velox/connectors/Connector.h"
 #include "velox/connectors/hive/PartitionIdGenerator.h"
+#include "velox/dwio/parquet/writer/Writer.h"
 
 namespace facebook::velox::dwrf {
 class Writer;
@@ -186,7 +187,8 @@ class HiveDataSink : public DataSink {
       RowTypePtr inputType,
       std::shared_ptr<const HiveInsertTableHandle> insertTableHandle,
       const ConnectorQueryCtx* connectorQueryCtx,
-      CommitStrategy commitStrategy);
+      CommitStrategy commitStrategy,
+      std::string format = "dwrf");
 
   void appendData(RowVectorPtr input) override;
 
@@ -225,6 +227,7 @@ class HiveDataSink : public DataSink {
   // writers_ are both indexed by partitionId.
   std::vector<std::shared_ptr<HiveWriterInfo>> writerInfo_;
   std::vector<std::unique_ptr<dwrf::Writer>> writers_;
+  std::vector<std::unique_ptr<parquet::Writer>> parquetWriters_;
 
   // Below are structures updated when processing current input. partitionIds_
   // are indexed by the row of input_. partitionRows_, rawPartitionRows_ and
@@ -233,6 +236,7 @@ class HiveDataSink : public DataSink {
   std::vector<BufferPtr> partitionRows_;
   std::vector<vector_size_t*> rawPartitionRows_;
   std::vector<vector_size_t> partitionSizes_;
+  std::string format_;
 };
 
 } // namespace facebook::velox::connector::hive

--- a/velox/connectors/tpch/TpchConnector.h
+++ b/velox/connectors/tpch/TpchConnector.h
@@ -153,7 +153,8 @@ class TpchConnector final : public Connector {
       std::shared_ptr<
           ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
-      CommitStrategy /*commitStrategy*/) override final {
+      CommitStrategy /*commitStrategy*/,
+      std::string format = "dwrf") override final {
     VELOX_NYI("TpchConnector does not support data sink.");
   }
 };

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -471,14 +471,16 @@ class TableWriteNode : public PlanNode {
       const std::shared_ptr<InsertTableHandle>& insertTableHandle,
       const RowTypePtr& outputType,
       connector::CommitStrategy commitStrategy,
-      const PlanNodePtr& source)
+      const PlanNodePtr& source,
+      const std::string format = "DWRF")
       : PlanNode(id),
         sources_{source},
         columns_{columns},
         columnNames_{columnNames},
         insertTableHandle_(insertTableHandle),
         outputType_(outputType),
-        commitStrategy_(commitStrategy) {
+        commitStrategy_(commitStrategy),
+        format_(format) {
     VELOX_CHECK_EQ(columns->size(), columnNames.size());
     for (const auto& column : columns->names()) {
       VELOX_CHECK(source->outputType()->containsChild(column));
@@ -491,6 +493,10 @@ class TableWriteNode : public PlanNode {
 
   const RowTypePtr& outputType() const override {
     return outputType_;
+  }
+
+  const std::string& format() const {
+    return format_;
   }
 
   // The subset of columns in the output of the source node, potentially in
@@ -530,6 +536,7 @@ class TableWriteNode : public PlanNode {
   const std::shared_ptr<InsertTableHandle> insertTableHandle_;
   const RowTypePtr outputType_;
   const connector::CommitStrategy commitStrategy_;
+  const std::string format_;
 };
 
 class AggregationNode : public PlanNode {

--- a/velox/exec/TableWriter.cpp
+++ b/velox/exec/TableWriter.cpp
@@ -33,7 +33,8 @@ TableWriter::TableWriter(
       driverCtx_(driverCtx),
       insertTableHandle_(
           tableWriteNode->insertTableHandle()->connectorInsertTableHandle()),
-      commitStrategy_(tableWriteNode->commitStrategy()) {
+      commitStrategy_(tableWriteNode->commitStrategy()),
+      format_(tableWriteNode->format()) {
   const auto& connectorId = tableWriteNode->insertTableHandle()->connectorId();
   connector_ = connector::getConnector(connectorId);
   connectorQueryCtx_ =
@@ -58,7 +59,8 @@ void TableWriter::createDataSink() {
       mappedType_,
       insertTableHandle_,
       connectorQueryCtx_.get(),
-      commitStrategy_);
+      commitStrategy_,
+      format_);
 }
 
 void TableWriter::addInput(RowVectorPtr input) {

--- a/velox/exec/TableWriter.h
+++ b/velox/exec/TableWriter.h
@@ -77,5 +77,6 @@ class TableWriter : public Operator {
   bool finished_ = false;
   bool closed_ = false;
   vector_size_t numWrittenRows_ = 0;
+  std::string format_ = "DWRF";
 };
 } // namespace facebook::velox::exec

--- a/velox/exec/tests/AsyncConnectorTest.cpp
+++ b/velox/exec/tests/AsyncConnectorTest.cpp
@@ -151,7 +151,8 @@ class TestConnector : public connector::Connector {
       std::shared_ptr<
           ConnectorInsertTableHandle> /*connectorInsertTableHandle*/,
       ConnectorQueryCtx* /*connectorQueryCtx*/,
-      CommitStrategy /*commitStrategy*/) override final {
+      CommitStrategy /*commitStrategy*/,
+      std::string format = "dwrf") override final {
     VELOX_NYI();
   }
 };

--- a/velox/substrait/CMakeLists.txt
+++ b/velox/substrait/CMakeLists.txt
@@ -60,7 +60,7 @@ add_library(velox_substrait_plan_converter ${SRCS})
 target_include_directories(velox_substrait_plan_converter
                            PUBLIC ${PROTO_OUTPUT_DIR})
 target_link_libraries(velox_substrait_plan_converter velox_connector
-                      velox_dwio_dwrf_common velox_functions_spark)
+                      velox_dwio_dwrf_common velox_functions_spark velox_dwio_parquet_writer)
 
 if(${VELOX_BUILD_TESTING})
   add_subdirectory(tests)

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -49,6 +49,9 @@ class SubstraitVeloxPlanConverter {
       memory::MemoryPool* pool,
       bool validationMode = false)
       : pool_(pool), validationMode_(validationMode) {}
+  /// Used to convert Substrait WriteRel into Velox PlanNode.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::WriteRel& sWrite);
+
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& sExpand);
 
@@ -187,7 +190,8 @@ class SubstraitVeloxPlanConverter {
     /// existing conditions for this field.
     bool setLeftBound(bool forOrRelation = false) {
       if (forOrRelation) {
-        if (!rightBound_) leftBound_ = true;
+        if (!rightBound_)
+          leftBound_ = true;
         return !rightBound_;
       }
       if (leftBound_ || inRange_ || multiRange_) {
@@ -201,7 +205,8 @@ class SubstraitVeloxPlanConverter {
     /// existing conditions for this field.
     bool setRightBound(bool forOrRelation = false) {
       if (forOrRelation) {
-        if (!leftBound_) rightBound_ = true;
+        if (!leftBound_)
+          rightBound_ = true;
         return !leftBound_;
       }
       if (rightBound_ || inRange_ || multiRange_) {

--- a/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -29,6 +29,9 @@ class SubstraitToVeloxPlanValidator {
       core::ExecCtx* execCtx)
       : pool_(pool), execCtx_(execCtx) {}
 
+  /// Used to validate whether the computing of this Write is supported.
+  bool validate(const ::substrait::WriteRel& writeRel);
+
   /// Used to validate whether the computing of this Limit is supported.
   bool validate(const ::substrait::FetchRel& fetchRel);
 
@@ -103,8 +106,8 @@ class SubstraitToVeloxPlanValidator {
 
   /// Validate Substrait Cast expression.
   bool validateCast(
-    const ::substrait::Expression::Cast& castExpr,
-    const RowTypePtr& inputType);  
+      const ::substrait::Expression::Cast& castExpr,
+      const RowTypePtr& inputType);
 
   /// Validate Substrait expression.
   bool validateExpression(

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -403,7 +403,20 @@ message Rel {
     MergeJoinRel merge_join = 14;
     ExpandRel expand = 15;
     WindowRel window = 16;
+    GenerateRel generate = 17;
+    WriteRel write = 18;
   }
+}
+
+message GenerateRel {
+  RelCommon common = 1;
+  Rel input = 2;
+  
+  Expression generator = 3;
+  repeated Expression child_output = 4;
+  bool outer = 5;
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
 
 // A base object for writing (e.g., a table or a view).


### PR DESCRIPTION
1. Add parquet write support in `TableWrite `operator.
2. Add validation and plan convert in `SubstraitToVeloxPlanValidator `and `SubstraitToVeloxPlan`.
3. Add `WriteRel `operator in substrait.