### PR TITLE
Change abs to std::abs in decimal operator

### DIFF
--- a/velox/type/DecimalUtil.h
+++ b/velox/type/DecimalUtil.h
@@ -387,7 +387,7 @@ class DecimalUtil {
       new_value = value;
       sig = 1;
     } else if (value < 0) {
-      new_value = abs(value);
+      new_value = std::abs(value);
       sig = -1;
     } else {
       new_value = value;
@@ -436,7 +436,7 @@ class DecimalUtil {
       new_value = value;
       sig = 1;
     } else if (value < 0) {
-      new_value = abs(value);
+      new_value = std::abs(value);
       sig = -1;
     } else {
       new_value = value;


### PR DESCRIPTION
Refer [PR#23](https://github.com/JkSelf/velox/pull/23) to use std::abs instead of abs. Because `abs(int 128)` will cause result mismatch.