### PR TITLE
Add format check for oap/velox

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,3 +24,20 @@ jobs:
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
           make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+
+  formatting-check:
+    name: Formatting Check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        path:
+          - check: 'velox'
+            exclude: 'external'
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run clang-format style check for C/C++ programs.
+        uses: jidicula/clang-format-action@v3.5.1
+        with:
+          clang-format-version: '12'
+          check-path: ${{ matrix.path['check'] }}
+          exclude-regex: ${{ matrix.path['exclude'] }}

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -182,6 +182,7 @@ def get_commit(files):
 
 def get_files(commit, path):
     filelist = []
+
     if commit != "":
         status, stdout, stderr = util.run(
             f"git diff --relative --name-only --diff-filter='ACM' {commit}"

--- a/scripts/check.py
+++ b/scripts/check.py
@@ -182,7 +182,6 @@ def get_commit(files):
 
 def get_files(commit, path):
     filelist = []
-
     if commit != "":
         status, stdout, stderr = util.run(
             f"git diff --relative --name-only --diff-filter='ACM' {commit}"

--- a/velox/common/base/SimdUtil-inl.h
+++ b/velox/common/base/SimdUtil-inl.h
@@ -1031,8 +1031,8 @@ struct Crc32<uint64_t, A> {
 #if XSIMD_WITH_NEON
   static uint32_t apply(uint32_t checksum, uint64_t value, const xsimd::neon&) {
     __asm__("crc32cx %w[c], %w[c], %x[v]"
-            : [ c ] "+r"(checksum)
-            : [ v ] "r"(value));
+            : [c] "+r"(checksum)
+            : [v] "r"(value));
     return checksum;
   }
 #endif

--- a/velox/common/file/tests/FileTest.cpp
+++ b/velox/common/file/tests/FileTest.cpp
@@ -67,9 +67,7 @@ void readData(ReadFile* readFile, bool checkFileSize = true) {
       folly::Range<char*>(middle, sizeof(middle)),
       folly::Range<char*>(
           nullptr,
-          (char*)(uint64_t)(
-              15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) -
-              sizeof(tail))),
+          (char*)(uint64_t)(15 + kOneMB - 500000 - sizeof(head) - sizeof(middle) - sizeof(tail))),
       folly::Range<char*>(tail, sizeof(tail))};
   ASSERT_EQ(15 + kOneMB, readFile->preadv(0, buffers));
   ASSERT_EQ(std::string_view(head, sizeof(head)), "aaaaabbbbbcc");

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -317,9 +317,7 @@ ExpandNode::ExpandNode(
     PlanNodePtr source)
     : PlanNode(std::move(id)),
       sources_{source},
-      outputType_(getSparkExpandOutputType(
-          projectSets,
-          names)),
+      outputType_(getSparkExpandOutputType(projectSets, names)),
       projectSets_(std::move(projectSets)),
       names_(std::move(names)) {}
 
@@ -346,8 +344,9 @@ folly::dynamic ExpandNode::serialize() const {
 PlanNodePtr ExpandNode::create(const folly::dynamic& obj, void* context) {
   auto source = deserializeSingleSource(obj, context);
   auto names = deserializeStrings(obj["names"]);
-    auto projectSets = ISerializable::deserialize<
-      std::vector<std::vector<ITypedExpr>>>(obj["projectSets"], context);
+  auto projectSets =
+      ISerializable::deserialize<std::vector<std::vector<ITypedExpr>>>(
+          obj["projectSets"], context);
   return std::make_shared<ExpandNode>(
       deserializePlanNodeId(obj),
       std::move(projectSets),

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -673,7 +673,6 @@ inline std::string mapAggregationStepToName(const AggregationNode::Step& step) {
 /// similar behavior to spark ExpandExec.
 class ExpandNode : public PlanNode {
  public:
-
   /// @param id Plan node ID.
   /// @param projectSets A list of project sets. The output conatins one cloumn
   /// for each project expr. The project expr may be cloumn reference, null or
@@ -694,8 +693,7 @@ class ExpandNode : public PlanNode {
     return sources_;
   }
 
-  const std::vector<std::vector<TypedExprPtr>>& projectSets()
-      const {
+  const std::vector<std::vector<TypedExprPtr>>& projectSets() const {
     return projectSets_;
   }
 

--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -79,9 +79,10 @@ class QueryConfig {
   static constexpr const char* kCastIntByTruncate =
       "driver.cast.int_by_truncate";
 
-  // Allow decimal in casting varchar to int. The fractional part will be ignored.
+  // Allow decimal in casting varchar to int. The fractional part will be
+  // ignored.
   static constexpr const char* kCastIntAllowDecimal =
-       "driver.cast.int_allow_decimal";
+      "driver.cast.int_allow_decimal";
 
   static constexpr const char* kMaxLocalExchangeBufferSize =
       "max_local_exchange_buffer_size";

--- a/velox/dwio/common/InputStream.cpp
+++ b/velox/dwio/common/InputStream.cpp
@@ -154,8 +154,7 @@ void InputStream::vread(
       ranges.push_back(folly::Range<char*>(nullptr, curOffset - lastEnd));
     }
     ranges.push_back(
-      folly::Range<char*>(static_cast<char*>(buffers[i]),
-      r.length));
+        folly::Range<char*>(static_cast<char*>(buffers[i]), r.length));
     lastEnd = curOffset + r.length;
   }
   read(ranges, offset, purpose);

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -328,8 +328,7 @@ class ColumnStats : public AbstractColumnStats {
     int64_t value = getIntegerValue(max);
     int64_t lower = value > 0 ? value : value * (-1);
     int64_t upper = value > 0 ? value * (-1) : value;
-    return std::make_unique<velox::common::BigintRange>(
-        lower, upper, false);
+    return std::make_unique<velox::common::BigintRange>(lower, upper, false);
   }
 
   // The sample size is 65536.

--- a/velox/dwio/parquet/reader/StringColumnReader.cpp
+++ b/velox/dwio/parquet/reader/StringColumnReader.cpp
@@ -133,8 +133,9 @@ void StringColumnReader::getValues(RowSet rows, VectorPtr* result) {
 
     *result = std::make_shared<DictionaryVector<StringView>>(
         &memoryPool_,
-        !anyNulls_ ? nullptr
-                   : returnReaderNulls_ ? nullsInReadRange_ : resultNulls_,
+        !anyNulls_               ? nullptr
+            : returnReaderNulls_ ? nullsInReadRange_
+                                 : resultNulls_,
         numValues_,
         dictionaryValues,
         values_);

--- a/velox/exec/Aggregate.cpp
+++ b/velox/exec/Aggregate.cpp
@@ -67,8 +67,8 @@ bool registerAggregateFunction(
     // RegisterAdapter::registerPartialFunction(name, signatures);
     RegisterAdapter::registerMergeFunction(name, signatures);
     // RegisterAdapter::registerExtractFunction(name, signatures);
-    // TODO: register retract function only when the original UDAF supports retracting.
-    // RegisterAdapter::registerRetractFunction(name, signatures);
+    // TODO: register retract function only when the original UDAF supports
+    // retracting. RegisterAdapter::registerRetractFunction(name, signatures);
   }
 
   return true;

--- a/velox/exec/AggregateFunctionAdapter.h
+++ b/velox/exec/AggregateFunctionAdapter.h
@@ -386,7 +386,8 @@ class RegisterAdapter {
     return signatures;
   }
 
-  static std::vector<AggregateFunctionSignaturePtr> countMergeFunctionSignatures(
+  static std::vector<AggregateFunctionSignaturePtr>
+  countMergeFunctionSignatures(
       const std::vector<AggregateFunctionSignaturePtr>& aggregateSignatures) {
     std::unordered_set<TypeSignature> distinctIntermediateTypes;
     std::vector<AggregateFunctionSignaturePtr> signatures;

--- a/velox/exec/Expand.cpp
+++ b/velox/exec/Expand.cpp
@@ -39,12 +39,14 @@ Expand::Expand(
     constantMapping.reserve(numProjects);
     for (const auto& project : projectSet) {
       if (auto field =
-        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(project)) {
+              std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(
+                  project)) {
         projectMapping.push_back(inputType->getChildIdx(field->name()));
         constantMapping.push_back(nullptr);
       } else if (
-        auto constant =
-          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(project)) {
+          auto constant =
+              std::dynamic_pointer_cast<const core::ConstantTypedExpr>(
+                  project)) {
         projectMapping.push_back(kUnMapedProject);
         constantMapping.push_back(constant);
       } else {
@@ -90,14 +92,11 @@ RowVectorPtr Expand::getOutput() {
       if (constantExpr->value().isNull()) {
         // Add null column.
         outputColumns[i] = BaseVector::createNullConstant(
-          outputType_->childAt(i), numInput, pool());
+            outputType_->childAt(i), numInput, pool());
       } else {
         // Add constant column: gid, gpos, etc.
         outputColumns[i] = BaseVector::createConstant(
-          constantExpr->type(),
-          constantExpr->value(),
-          numInput,
-          pool());
+            constantExpr->type(), constantExpr->value(), numInput, pool());
       }
     } else {
       outputColumns[i] = input_->childAt(projectMapping[i]);

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -22,6 +22,7 @@
 #include "velox/exec/CrossJoinProbe.h"
 #include "velox/exec/EnforceSingleRow.h"
 #include "velox/exec/Exchange.h"
+#include "velox/exec/Expand.h"
 #include "velox/exec/FilterProject.h"
 #include "velox/exec/GroupId.h"
 #include "velox/exec/HashAggregation.h"
@@ -32,7 +33,6 @@
 #include "velox/exec/MergeJoin.h"
 #include "velox/exec/OrderBy.h"
 #include "velox/exec/PartitionedOutput.h"
-#include "velox/exec/Expand.h"
 #include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/TableWriter.h"
@@ -457,8 +457,7 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
     } else if (
         auto expandNode =
             std::dynamic_pointer_cast<const core::ExpandNode>(planNode)) {
-      operators.push_back(
-          std::make_unique<Expand>(id, ctx.get(), expandNode));
+      operators.push_back(std::make_unique<Expand>(id, ctx.get(), expandNode));
     } else if (
         auto groupIdNode =
             std::dynamic_pointer_cast<const core::GroupIdNode>(planNode)) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1302,23 +1302,24 @@ TEST_F(AggregationTest, groupingSetsByExpand) {
   createDuckDbTable({data});
   // Compute a subset of aggregates per grouping set by using masks based on
   // group_id column.
-  auto plan = PlanBuilder()
-             .values({data})
-             .expand({{"k1", "", "a", "b", "0"}, {"", "k2", "a", "b", "1"}})
-             .project(
-                 {"k1",
-                  "k2",
-                  "group_id_0",
-                  "a",
-                  "b",
-                  "group_id_0 = 0 as mask_a",
-                  "group_id_0 = 1 as mask_b"})
-             .singleAggregation(
-                 {"k1", "k2", "group_id_0"},
-                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"},
-                 {"", "mask_a", "mask_b"})
-             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
-             .planNode();
+  auto plan =
+      PlanBuilder()
+          .values({data})
+          .expand({{"k1", "", "a", "b", "0"}, {"", "k2", "a", "b", "1"}})
+          .project(
+              {"k1",
+               "k2",
+               "group_id_0",
+               "a",
+               "b",
+               "group_id_0 = 0 as mask_a",
+               "group_id_0 = 1 as mask_b"})
+          .singleAggregation(
+              {"k1", "k2", "group_id_0"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"},
+              {"", "mask_a", "mask_b"})
+          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
 
   assertQuery(
       plan,
@@ -1330,10 +1331,11 @@ TEST_F(AggregationTest, groupingSetsByExpand) {
   plan = PlanBuilder()
              .values({data})
              .expand({
-                {"k1", "k2", "a", "b", "0"},
-                {"k1", "", "a", "b", "1"},
-                {"", "k2", "a", "b", "2"},
-                {"", "", "a", "b", "3"},})
+                 {"k1", "k2", "a", "b", "0"},
+                 {"k1", "", "a", "b", "1"},
+                 {"", "k2", "a", "b", "2"},
+                 {"", "", "a", "b", "3"},
+             })
              .singleAggregation(
                  {"k1", "k2", "group_id_0"},
                  {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
@@ -1347,10 +1349,10 @@ TEST_F(AggregationTest, groupingSetsByExpand) {
   // Rollup.
   plan = PlanBuilder()
              .values({data})
-             .expand({
-                {"k1", "k2", "a", "b", "0"},
-                {"k1", "", "a", "b", "1"},
-                {"", "", "a", "b", "2"}})
+             .expand(
+                 {{"k1", "k2", "a", "b", "0"},
+                  {"k1", "", "a", "b", "1"},
+                  {"", "", "a", "b", "2"}})
              .singleAggregation(
                  {"k1", "k2", "group_id_0"},
                  {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
@@ -1360,18 +1362,17 @@ TEST_F(AggregationTest, groupingSetsByExpand) {
   assertQuery(
       plan,
       "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
-  plan =
-      PlanBuilder()
-          .values({data})
-          .expand({
-                {"k1", "", "a", "b", "0", "0"},
-                {"k1", "", "a", "b", "0", "1"},
-                {"", "k2", "a", "b", "1", "2"}})
-          .singleAggregation(
-              {"k1", "k2", "group_id_0", "group_id_1"},
-              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
-          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
-          .planNode();
+  plan = PlanBuilder()
+             .values({data})
+             .expand(
+                 {{"k1", "", "a", "b", "0", "0"},
+                  {"k1", "", "a", "b", "0", "1"},
+                  {"", "k2", "a", "b", "1", "2"}})
+             .singleAggregation(
+                 {"k1", "k2", "group_id_0", "group_id_1"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
 
   assertQuery(
       plan,

--- a/velox/exec/tests/MultiFragmentTest.cpp
+++ b/velox/exec/tests/MultiFragmentTest.cpp
@@ -1188,7 +1188,7 @@ DEBUG_ONLY_TEST_F(
       kRootTaskId,
       rootPlan,
       0,
-      [](RowVectorPtr /*unused*/, ContinueFuture *
+      [](RowVectorPtr /*unused*/, ContinueFuture*
          /*unused*/) -> BlockingReason { return BlockingReason::kNotBlocked; },
       kRootMemoryLimit);
   Task::start(rootTask, 1);

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -236,9 +236,7 @@ TEST_F(PlanNodeToStringTest, aggregation) {
 TEST_F(PlanNodeToStringTest, expand) {
   auto plan = PlanBuilder()
                   .values({data_})
-                  .expand({
-                    {"c0", "", "c2", "0"},
-                    {"", "c1", "c2", "1"}})
+                  .expand({{"c0", "", "c2", "0"}, {"", "c1", "c2", "1"}})
                   .planNode();
   ASSERT_EQ("-- Expand\n", plan->toString());
   ASSERT_EQ(

--- a/velox/exec/tests/VectorHasherTest.cpp
+++ b/velox/exec/tests/VectorHasherTest.cpp
@@ -743,9 +743,9 @@ void append(FlatVectorPtr<T>& vector, Value id) {
   } else {
     vector->set(
         size,
-        id == Value::kMin
-            ? std::numeric_limits<T>::min()
-            : id == Value::kMax ? std::numeric_limits<T>::max() : 0);
+        id == Value::kMin       ? std::numeric_limits<T>::min()
+            : id == Value::kMax ? std::numeric_limits<T>::max()
+                                : 0);
   }
 }
 } // namespace

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -687,7 +687,7 @@ PlanBuilder& PlanBuilder::expand(
         if (planNode_->outputType()->containsChild(projectionSets[j][i])) {
           names.push_back(projectionSets[j][i]);
           types.push_back(
-            field(planNode_->outputType(), projectionSets[j][i])->type());
+              field(planNode_->outputType(), projectionSets[j][i])->type());
         } else {
           names.push_back(groupIdPrefix + std::to_string(grouIdColCount++));
           types.push_back(BIGINT());
@@ -702,15 +702,13 @@ PlanBuilder& PlanBuilder::expand(
     projectExprs.reserve(projectionSet.size());
     for (int i = 0; i < projectionSet.size(); ++i) {
       if (projectionSet[i] == "") {
-        projectExprs.push_back(
-          std::make_shared<core::ConstantTypedExpr>(
+        projectExprs.push_back(std::make_shared<core::ConstantTypedExpr>(
             types[i], variant::null(types[i]->kind())));
       } else if (planNode_->outputType()->containsChild(projectionSet[i])) {
         projectExprs.push_back(
-          field(planNode_->outputType(), projectionSet[i]));
+            field(planNode_->outputType(), projectionSet[i]));
       } else {
-        projectExprs.push_back(
-          std::make_shared<core::ConstantTypedExpr>(
+        projectExprs.push_back(std::make_shared<core::ConstantTypedExpr>(
             BIGINT(), variant(std::stol(projectionSet[i]))));
       }
     }
@@ -718,10 +716,7 @@ PlanBuilder& PlanBuilder::expand(
   }
 
   planNode_ = std::make_shared<core::ExpandNode>(
-      nextPlanNodeId(),
-      projectSetExprs,
-      std::move(names),
-      planNode_);
+      nextPlanNodeId(), projectSetExprs, std::move(names), planNode_);
 
   return *this;
 }

--- a/velox/exec/tests/utils/SumNonPODAggregate.cpp
+++ b/velox/exec/tests/utils/SumNonPODAggregate.cpp
@@ -156,7 +156,7 @@ bool registerSumNonPODAggregate(const std::string& name, int alignment) {
       [alignment](
           velox::core::AggregationNode::Step /*step*/,
           const std::vector<velox::TypePtr>& /*argTypes*/,
-          const velox::TypePtr &
+          const velox::TypePtr&
           /*resultType*/) -> std::unique_ptr<velox::exec::Aggregate> {
         return std::make_unique<SumNonPODAggregate>(velox::BIGINT(), alignment);
       });

--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -55,12 +55,14 @@ void applyCastKernel(
     if constexpr (
         CppToType<From>::typeKind == TypeKind::SHORT_DECIMAL ||
         CppToType<From>::typeKind == TypeKind::LONG_DECIMAL) {
-      output = util::Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::cast(
-          input->valueAt(row), nullOutput, input->type());
+      output = util::
+          Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
+              cast(input->valueAt(row), nullOutput, input->type());
 
     } else {
-      output = util::Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::cast(
-          input->valueAt(row), nullOutput);
+      output = util::
+          Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
+              cast(input->valueAt(row), nullOutput);
     }
 
     if (!nullOutput) {
@@ -76,16 +78,16 @@ void applyCastKernel(
     if constexpr (
         CppToType<From>::typeKind == TypeKind::SHORT_DECIMAL ||
         CppToType<From>::typeKind == TypeKind::LONG_DECIMAL) {
-      auto output =
-          util::Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::cast(
-              input->valueAt(row), nullOutput, input->type());
+      auto output = util::
+          Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
+              cast(input->valueAt(row), nullOutput, input->type());
       if (!nullOutput) {
         result->set(row, output);
       }
     } else {
-      auto output =
-          util::Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::cast(
-              input->valueAt(row), nullOutput);
+      auto output = util::
+          Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
+              cast(input->valueAt(row), nullOutput);
       if (!nullOutput) {
         result->set(row, output);
       }
@@ -248,10 +250,10 @@ void CastExpr::applyCastWithTry(
         // Passing a false truncate flag
         if (isCastIntAllowDecimal) {
           applyCastKernel<To, From, false, true>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+              row, inputSimpleVector, resultFlatVector, nullOutput);
         } else {
           applyCastKernel<To, From, false, false>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+              row, inputSimpleVector, resultFlatVector, nullOutput);
         }
       } catch (const VeloxRuntimeError& re) {
         VELOX_FAIL(
@@ -278,10 +280,10 @@ void CastExpr::applyCastWithTry(
         // Passing a true truncate flag
         if (isCastIntAllowDecimal) {
           applyCastKernel<To, From, true, true>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+              row, inputSimpleVector, resultFlatVector, nullOutput);
         } else {
           applyCastKernel<To, From, true, false>(
-            row, inputSimpleVector, resultFlatVector, nullOutput);
+              row, inputSimpleVector, resultFlatVector, nullOutput);
         }
       } catch (const VeloxRuntimeError& re) {
         VELOX_FAIL(

--- a/velox/expression/ExprCompiler.cpp
+++ b/velox/expression/ExprCompiler.cpp
@@ -220,7 +220,8 @@ ExprPtr getRowConstructorWithNullExpr(
   static auto rowConstructorVectorFunction =
       vectorFunctionFactories().withRLock([](auto& functionMap) {
         auto functionIterator = functionMap.find(exec::kRowConstructorWithNull);
-        return functionIterator->second.factory(exec::kRowConstructorWithNull, {});
+        return functionIterator->second.factory(
+            exec::kRowConstructorWithNull, {});
       });
 
   return std::make_shared<Expr>(

--- a/velox/expression/tests/CastExprTest.cpp
+++ b/velox/expression/tests/CastExprTest.cpp
@@ -45,10 +45,9 @@ class CastExprTest : public functions::test::CastBaseTest {
   }
 
   void setCastIntAllowDecimalAndByTruncate(bool value) {
-    queryCtx_->setConfigOverridesUnsafe({
-        {core::QueryConfig::kCastIntAllowDecimal, std::to_string(value)},
-        {core::QueryConfig::kCastIntByTruncate, std::to_string(value)}
-    });
+    queryCtx_->setConfigOverridesUnsafe(
+        {{core::QueryConfig::kCastIntAllowDecimal, std::to_string(value)},
+         {core::QueryConfig::kCastIntByTruncate, std::to_string(value)}});
   }
 
   void setCastMatchStructByName(bool value) {
@@ -551,17 +550,7 @@ TEST_F(CastExprTest, allowDecimal) {
   // Allow decimal.
   setCastIntAllowDecimalAndByTruncate(true);
   testCast<std::string, int32_t>(
-      "int",
-      {"-.",
-       "0.0",
-       "125.5",
-       "-128.3"},
-      {0,
-       0,
-       125,
-       -128},
-      false,
-      true);
+      "int", {"-.", "0.0", "125.5", "-128.3"}, {0, 0, 125, -128}, false, true);
 }
 
 constexpr vector_size_t kVectorSize = 1'000;

--- a/velox/expression/tests/ExprEncodingsTest.cpp
+++ b/velox/expression/tests/ExprEncodingsTest.cpp
@@ -550,9 +550,9 @@ TEST_P(ExprEncodingsTest, conditional) {
   run<int64_t>(
       "if(bigint1 % 2 = 0, 2 * bigint1 + 10, 3 * bigint2) + 11",
       [&](int32_t row) {
-        auto temp = (IS_BIGINT1 && BIGINT1 % 2 == 0)
-            ? INT64V(2 * BIGINT1 + 10)
-            : IS_BIGINT2 ? INT64V(3 * BIGINT2) : INT64N;
+        auto temp = (IS_BIGINT1 && BIGINT1 % 2 == 0) ? INT64V(2 * BIGINT1 + 10)
+            : IS_BIGINT2                             ? INT64V(3 * BIGINT2)
+                                                     : INT64N;
         return temp.has_value() ? INT64V(temp.value() + 11) : temp;
       });
 }

--- a/velox/functions/prestosql/RowFunctionWithNull.cpp
+++ b/velox/functions/prestosql/RowFunctionWithNull.cpp
@@ -29,8 +29,8 @@ class RowFunctionWithNull : public exec::VectorFunction {
       VectorPtr& result) const override {
     auto argsCopy = args;
 
-    BufferPtr nulls =
-        AlignedBuffer::allocate<char>(bits::nbytes(rows.size()), context.pool(), 1);
+    BufferPtr nulls = AlignedBuffer::allocate<char>(
+        bits::nbytes(rows.size()), context.pool(), 1);
     auto* nullsPtr = nulls->asMutable<uint64_t>();
     auto cntNull = 0;
     rows.applyToSelected([&](vector_size_t i) {
@@ -49,7 +49,12 @@ class RowFunctionWithNull : public exec::VectorFunction {
     });
 
     RowVectorPtr localResult = std::make_shared<RowVector>(
-        context.pool(), outputType, nulls, rows.size(), std::move(argsCopy), cntNull /*nullCount*/);
+        context.pool(),
+        outputType,
+        nulls,
+        rows.size(),
+        std::move(argsCopy),
+        cntNull /*nullCount*/);
     context.moveOrCopyResult(localResult, rows, result);
   }
 

--- a/velox/functions/prestosql/aggregates/SumAggregate.h
+++ b/velox/functions/prestosql/aggregates/SumAggregate.h
@@ -54,8 +54,8 @@ class SumAggregate
         groups, numGroups, result, [&](char* group) {
           // 'ResultType' and 'TAccumulator' might not be same such as sum(real)
           // and we do an explicit type conversion here.
-          return (ResultType)(
-              *BaseAggregate::Aggregate::template value<TAccumulator>(group));
+          return (ResultType)(*BaseAggregate::Aggregate::template value<
+                              TAccumulator>(group));
         });
   }
 

--- a/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/GeneralFunctionsRegistration.cpp
@@ -23,7 +23,8 @@ namespace facebook::velox::functions {
 void registerAllSpecialFormGeneralFunctions() {
   VELOX_REGISTER_VECTOR_FUNCTION(udf_in, "in");
   VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row, "row_constructor");
-  VELOX_REGISTER_VECTOR_FUNCTION(udf_concat_row_with_null, "row_constructor_with_null");
+  VELOX_REGISTER_VECTOR_FUNCTION(
+      udf_concat_row_with_null, "row_constructor_with_null");
   registerIsNullFunction("is_null");
 }
 

--- a/velox/functions/prestosql/window/CumeDist.cpp
+++ b/velox/functions/prestosql/window/CumeDist.cpp
@@ -81,7 +81,7 @@ void registerCumeDist(const std::string& name) {
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& /*resultType*/,
           velox::memory::MemoryPool* /*pool*/,
-          HashStringAllocator *
+          HashStringAllocator*
           /*stringAllocator*/) -> std::unique_ptr<exec::WindowFunction> {
         return std::make_unique<CumeDistFunction>();
       });

--- a/velox/functions/prestosql/window/Ntile.cpp
+++ b/velox/functions/prestosql/window/Ntile.cpp
@@ -245,7 +245,7 @@ void registerNtile(const std::string& name) {
           const std::vector<exec::WindowFunctionArg>& args,
           const TypePtr& /*resultType*/,
           velox::memory::MemoryPool* pool,
-          HashStringAllocator *
+          HashStringAllocator*
           /*stringAllocator*/) -> std::unique_ptr<exec::WindowFunction> {
         return std::make_unique<NtileFunction>(args, pool);
       });

--- a/velox/functions/prestosql/window/Rank.cpp
+++ b/velox/functions/prestosql/window/Rank.cpp
@@ -107,7 +107,7 @@ void registerRankInternal(
           const std::vector<exec::WindowFunctionArg>& /*args*/,
           const TypePtr& resultType,
           velox::memory::MemoryPool* /*pool*/,
-          HashStringAllocator *
+          HashStringAllocator*
           /*stringAllocator*/) -> std::unique_ptr<exec::WindowFunction> {
         return std::make_unique<RankFunction<TRank, TResult>>(resultType);
       });

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -247,13 +247,12 @@ bool SubstraitToVeloxPlanValidator::validate(
             case ::substrait::Expression::RexTypeCase::kLiteral:
               break;
             default:
-              std::cout << "Only field or literal is supported."
-                        << std::endl;
+              std::cout << "Only field or literal is supported." << std::endl;
               return false;
           }
           if (rowType) {
             expressions.emplace_back(
-              exprConverter_->toVeloxExpr(projectExpr, rowType));
+                exprConverter_->toVeloxExpr(projectExpr, rowType));
           }
         }
 
@@ -262,7 +261,7 @@ bool SubstraitToVeloxPlanValidator::validate(
           // function or mismatched type, exception will be thrown.
           exec::ExprSet exprSet(std::move(expressions), execCtx_);
         }
-        
+
       } catch (const VeloxException& err) {
         std::cout << "Validation failed for expressions in ExpandRel due to:"
                   << err.message() << std::endl;
@@ -677,7 +676,8 @@ bool SubstraitToVeloxPlanValidator::validate(
   return true;
 }
 
-TypePtr SubstraitToVeloxPlanValidator::getDecimalType(const std::string& decimalType) {
+TypePtr SubstraitToVeloxPlanValidator::getDecimalType(
+    const std::string& decimalType) {
   // Decimal info is in the format of dec<precision,scale>.
   auto precisionStart = decimalType.find_first_of('<');
   auto tokenIndex = decimalType.find_first_of(',');
@@ -694,13 +694,17 @@ TypePtr SubstraitToVeloxPlanValidator::getDecimalType(const std::string& decimal
   }
 }
 
-TypePtr SubstraitToVeloxPlanValidator::getRowType(const std::string& structType) {
+TypePtr SubstraitToVeloxPlanValidator::getRowType(
+    const std::string& structType) {
   // Struct info is in the format of struct<T1,T2, ...,Tn>.
   // TODO: nested struct is not supported.
   auto structStart = structType.find_first_of('<');
   auto structEnd = structType.find_last_of('>');
-  VELOX_CHECK(structEnd - structStart > 1, "More information is needed to create RowType");
-  std::string childrenTypes = structType.substr(structStart + 1, structEnd - structStart - 1);
+  VELOX_CHECK(
+      structEnd - structStart > 1,
+      "More information is needed to create RowType");
+  std::string childrenTypes =
+      structType.substr(structStart + 1, structEnd - structStart - 1);
 
   // Split the types with delimiter.
   std::string delimiter = ",";
@@ -713,10 +717,12 @@ TypePtr SubstraitToVeloxPlanValidator::getRowType(const std::string& structType)
     if (typeStr.find("dec") != std::string::npos) {
       std::size_t endPos = childrenTypes.find(decDelimiter);
       VELOX_CHECK(endPos >= pos + 1, "Decimal scale is expected.");
-      const auto& decimalStr = typeStr + childrenTypes.substr(pos, endPos - pos) + decDelimiter;
+      const auto& decimalStr =
+          typeStr + childrenTypes.substr(pos, endPos - pos) + decDelimiter;
       types.emplace_back(getDecimalType(decimalStr));
       names.emplace_back("");
-      childrenTypes.erase(0, endPos + delimiter.length() + decDelimiter.length());
+      childrenTypes.erase(
+          0, endPos + delimiter.length() + decDelimiter.length());
       continue;
     }
 
@@ -770,8 +776,9 @@ bool SubstraitToVeloxPlanValidator::validateAggRelFunctionType(
         exec::SignatureBinder binder(*signature, types);
         if (binder.tryBind()) {
           auto resolveType = binder.tryResolveType(
-              exec::isPartialOutput(planConverter_->toAggregationStep(aggRel)) ? signature->intermediateType()
-                                          : signature->returnType());
+              exec::isPartialOutput(planConverter_->toAggregationStep(aggRel))
+                  ? signature->intermediateType()
+                  : signature->returnType());
           if (resolveType == nullptr) {
             std::cout
                 << fmt::format(

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -30,7 +30,11 @@
 
 namespace facebook::velox::util {
 
-template <TypeKind KIND, typename = void, bool TRUNCATE = false, bool ALLOW_DECIMAL = false>
+template <
+    TypeKind KIND,
+    typename = void,
+    bool TRUNCATE = false,
+    bool ALLOW_DECIMAL = false>
 struct Converter {
   template <typename T>
   // nullOutput API requires that the user has already set nullOutput to
@@ -103,7 +107,8 @@ struct Converter<
             KIND == TypeKind::SMALLINT || KIND == TypeKind::INTEGER ||
             KIND == TypeKind::BIGINT,
         void>,
-    TRUNCATE, ALLOW_DECIMAL> {
+    TRUNCATE,
+    ALLOW_DECIMAL> {
   using T = typename TypeTraits<KIND>::NativeType;
 
   template <typename From>
@@ -151,7 +156,10 @@ struct Converter<
         "Conversion to {} is not supported", TypeTraits<KIND>::name);
   }
 
-  static T convertStringToInt(const folly::StringPiece& v, const bool allowDecimal, bool& nullOutput) {
+  static T convertStringToInt(
+      const folly::StringPiece& v,
+      const bool allowDecimal,
+      bool& nullOutput) {
     // Handling boolean target case fist because it is in this scope
     if constexpr (std::is_same_v<T, bool>) {
       return folly::to<T>(v);
@@ -224,7 +232,8 @@ struct Converter<
   static T cast(const StringView& v, bool& nullOutput) {
     try {
       if constexpr (TRUNCATE) {
-        return convertStringToInt(folly::StringPiece(v), ALLOW_DECIMAL, nullOutput);
+        return convertStringToInt(
+            folly::StringPiece(v), ALLOW_DECIMAL, nullOutput);
       } else {
         return folly::to<T>(folly::StringPiece(v));
       }
@@ -370,7 +379,8 @@ template <TypeKind KIND, bool TRUNCATE, bool ALLOW_DECIMAL>
 struct Converter<
     KIND,
     std::enable_if_t<KIND == TypeKind::REAL || KIND == TypeKind::DOUBLE, void>,
-    TRUNCATE, ALLOW_DECIMAL> {
+    TRUNCATE,
+    ALLOW_DECIMAL> {
   using T = typename TypeTraits<KIND>::NativeType;
 
   template <typename From>

--- a/velox/type/DecimalUtilOp.h
+++ b/velox/type/DecimalUtilOp.h
@@ -63,7 +63,9 @@ class DecimalUtilOp {
   // 10^scale_by,
   // this function returns the minimum number of leading zeros the result can
   // have.
-  inline static int32_t minLeadingZerosAfterScaling(int32_t numLz, int32_t scaleBy) {
+  inline static int32_t minLeadingZerosAfterScaling(
+      int32_t numLz,
+      int32_t scaleBy) {
     int32_t result = numLz - maxBitsRequiredIncreaseAfterScaling(scaleBy);
     return result;
   }

--- a/velox/type/Tokenizer.cpp
+++ b/velox/type/Tokenizer.cpp
@@ -18,7 +18,7 @@
 namespace facebook::velox::common {
 
 Tokenizer::Tokenizer(const std::string& path, bool dotAsRegular)
-  : path_(path), dotAsRegular_(dotAsRegular) {
+    : path_(path), dotAsRegular_(dotAsRegular) {
   state = State::kNotReady;
   index_ = 0;
 }
@@ -145,8 +145,8 @@ std::unique_ptr<Subfield::PathElement> Tokenizer::matchUnquotedSubscript() {
 }
 
 bool Tokenizer::isUnquotedPathCharacter(char c) {
-  bool unquoted = c == ':' || c == '$' || c == '-' || c == '/' || c == '@' || c == '|' ||
-      c == '#' || isUnquotedSubscriptCharacter(c);
+  bool unquoted = c == ':' || c == '$' || c == '-' || c == '/' || c == '@' ||
+      c == '|' || c == '#' || isUnquotedSubscriptCharacter(c);
   if (dotAsRegular_) {
     return unquoted || c == '.';
   }


### PR DESCRIPTION
1. add format-check for oap/velox.
2. keep consistent with meta/velox. (same clang-format config and same version).