### PR TITLE
Fix bloomfilter validation

### DIFF
--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -225,6 +225,9 @@ class BloomFilterAggAggregate : public exec::Aggregate {
     VELOX_USER_CHECK_GT(newVal, 0, "{} must be positive", name);
     if (val == kMissingArgument) {
       val = newVal;
+    } else {
+      VELOX_USER_CHECK_EQ(
+          newVal, val, "{} argument must be constant for all input rows", name);
     }
   }
 

--- a/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
@@ -246,8 +246,8 @@ class BloomFilterAggAggregate : public exec::Aggregate {
   // Reusable instance of DecodedVector for decoding input vectors.
   DecodedVector decodedRaw_;
   DecodedVector decodedIntermediate_;
-  int64_t originalEstimatedNumItems_;
-  int64_t originalNumBits_;
+  int64_t originalEstimatedNumItems_ = kMissingArgument;
+  int64_t originalNumBits_ = kMissingArgument;
   int64_t estimatedNumItems_ = kMissingArgument;
   int64_t numBits_ = kMissingArgument;
   int32_t capacity_ = kMissingArgument;


### PR DESCRIPTION
Encounter this error when we run q93, we increase settings "spark.sql.optimizer.runtime.bloomFilter.maxNumItems" for our tests. Constants check happens before min comparsion, so when next grouping comes, it failed with not constant value error.

Error Source: USER
Error Code: INVALID_ARGUMENT
Reason: (5404631 vs. 4000000) estimatedNumItems argument must be constant for all input rows
Retriable: False
Expression: newVal == val
Function: setConstantArgument
File: /var/git/Velox/velox/functions/sparksql/aggregates/BloomFilterAggAggregate.cpp
Line: 225