### PR TITLE
Minor: Set cmake build type to Release

### DIFF
--- a/scripts/setup-helper-functions.sh
+++ b/scripts/setup-helper-functions.sh
@@ -133,6 +133,7 @@ function cmake_install {
   # CMAKE_POSITION_INDEPENDENT_CODE is required so that Velox can be built into dynamic libraries \
   cmake -Wno-dev -B"${BINARY_DIR}" \
     -GNinja \
+    -DCMAKE_BUILD_TYPE=Release \
     -DCMAKE_POSITION_INDEPENDENT_CODE=ON \
     -DCMAKE_CXX_STANDARD=17 \
     "${INSTALL_PREFIX+-DCMAKE_PREFIX_PATH=}${INSTALL_PREFIX-}" \


### PR DESCRIPTION
This patch explicitly specified CMAKE_BUILD_TYPE=Release

some folly modules need this flag otherwise it will run with debug mode
https://github.com/facebook/folly/blob/main/folly/Benchmark.cpp#L641