### PR TITLE
Add expand op in velox

### DIFF
--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -321,12 +321,7 @@ ExpandNode::ExpandNode(
           projectSets,
           names)),
       projectSets_(std::move(projectSets)),
-      names_(std::move(names)) {
-  VELOX_CHECK_GE(
-      projectSets_.size(),
-      2,
-      "ExpandNode requires two or more project sets.");
-}
+      names_(std::move(names)) {}
 
 void ExpandNode::addDetails(std::stringstream& stream) const {
   for (auto i = 0; i < projectSets_.size(); ++i) {

--- a/velox/core/PlanNode.cpp
+++ b/velox/core/PlanNode.cpp
@@ -293,6 +293,74 @@ PlanNodePtr AggregationNode::create(const folly::dynamic& obj, void* context) {
 }
 
 namespace {
+RowTypePtr getSparkExpandOutputType(
+    const std::vector<std::vector<TypedExprPtr>>& projectSets,
+    const std::vector<std::string>& names) {
+  std::vector<std::string> outputs;
+  outputs.reserve(names.size());
+  std::vector<TypePtr> types;
+  types.reserve(names.size());
+  for (int32_t i = 0; i < names.size(); ++i) {
+    outputs.push_back(names[i]);
+    auto expr = projectSets[0][i];
+    types.push_back(expr->type());
+  }
+
+  return ROW(std::move(outputs), std::move(types));
+}
+} // namespace
+
+ExpandNode::ExpandNode(
+    PlanNodeId id,
+    std::vector<std::vector<TypedExprPtr>> projectSets,
+    std::vector<std::string> names,
+    PlanNodePtr source)
+    : PlanNode(std::move(id)),
+      sources_{source},
+      outputType_(getSparkExpandOutputType(
+          projectSets,
+          names)),
+      projectSets_(std::move(projectSets)),
+      names_(std::move(names)) {
+  VELOX_CHECK_GE(
+      projectSets_.size(),
+      2,
+      "ExpandNode requires two or more project sets.");
+}
+
+void ExpandNode::addDetails(std::stringstream& stream) const {
+  for (auto i = 0; i < projectSets_.size(); ++i) {
+    if (i > 0) {
+      stream << ", ";
+    }
+    stream << "[";
+    addKeys(stream, projectSets_[i]);
+    stream << "]";
+  }
+}
+
+folly::dynamic ExpandNode::serialize() const {
+  auto obj = PlanNode::serialize();
+  obj["projectSets"] = ISerializable::serialize(projectSets_);
+  obj["names"] = ISerializable::serialize(names_);
+
+  return obj;
+}
+
+// static
+PlanNodePtr ExpandNode::create(const folly::dynamic& obj, void* context) {
+  auto source = deserializeSingleSource(obj, context);
+  auto names = deserializeStrings(obj["names"]);
+    auto projectSets = ISerializable::deserialize<
+      std::vector<std::vector<ITypedExpr>>>(obj["projectSets"], context);
+  return std::make_shared<ExpandNode>(
+      deserializePlanNodeId(obj),
+      std::move(projectSets),
+      std::move(names),
+      std::move(source));
+}
+
+namespace {
 RowTypePtr getGroupIdOutputType(
     const std::vector<GroupIdNode::GroupingKeyInfo>& groupingKeyInfos,
     const std::vector<FieldAccessTypedExprPtr>& aggregationInputs,

--- a/velox/exec/CMakeLists.txt
+++ b/velox/exec/CMakeLists.txt
@@ -25,6 +25,7 @@ add_library(
   Driver.cpp
   EnforceSingleRow.cpp
   Exchange.cpp
+  Expand.cpp
   FilterProject.cpp
   GroupId.cpp
   GroupingSet.cpp

--- a/velox/exec/Expand.cpp
+++ b/velox/exec/Expand.cpp
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "velox/exec/Expand.h"
+
+namespace facebook::velox::exec {
+
+Expand::Expand(
+    int32_t operatorId,
+    DriverCtx* driverCtx,
+    const std::shared_ptr<const core::ExpandNode>& expandNode)
+    : Operator(
+          driverCtx,
+          expandNode->outputType(),
+          operatorId,
+          expandNode->id(),
+          "Expand") {
+  const auto& inputType = expandNode->sources()[0]->outputType();
+  auto numProjectSets = expandNode->projectSets().size();
+  projectMappings_.reserve(numProjectSets);
+  constantMappings_.reserve(numProjectSets);
+  auto numProjects = expandNode->names().size();
+  core::ConstantTypedExpr constPlaceholder(INTEGER(), 0);
+  for (const auto& projectSet : expandNode->projectSets()) {
+    std::vector<column_index_t> projectMapping;
+    projectMapping.reserve(numProjects);
+    std::vector<core::ConstantTypedExpr> constantMapping;
+    constantMapping.reserve(numProjects);
+    for (const auto& project : projectSet) {
+      if (auto field =
+        std::dynamic_pointer_cast<const core::FieldAccessTypedExpr>(project)) {
+        projectMapping.push_back(inputType->getChildIdx(field->name()));
+        constantMapping.push_back(constPlaceholder);
+      } else if (
+        auto constant =
+          std::dynamic_pointer_cast<const core::ConstantTypedExpr>(project)) {
+        projectMapping.push_back(kUnMapedProject);
+        constantMapping.push_back(*constant);
+      } else {
+        VELOX_FAIL("Unexpted expression for Expand");
+      }
+    }
+
+    projectMappings_.emplace_back(std::move(projectMapping));
+    constantMappings_.emplace_back(std::move(constantMapping));
+  }
+}
+
+bool Expand::needsInput() const {
+  return !noMoreInput_ && input_ == nullptr;
+}
+
+void Expand::addInput(RowVectorPtr input) {
+  // Load Lazy vectors.
+  for (auto& child : input->children()) {
+    child->loadedVector();
+  }
+
+  input_ = std::move(input);
+}
+
+RowVectorPtr Expand::getOutput() {
+  if (!input_) {
+    return nullptr;
+  }
+
+  // Make a copy of input for the grouping set at 'projectSetIndex_'.
+  auto numInput = input_->size();
+
+  std::vector<VectorPtr> outputColumns(outputType_->size());
+
+  const auto& projectMapping = projectMappings_[projectSetIndex_];
+  const auto& constantMapping = constantMappings_[projectSetIndex_];
+  auto numGroupingKeys = projectMapping.size();
+
+  for (auto i = 0; i < numGroupingKeys; ++i) {
+    if (projectMapping[i] == kUnMapedProject) {
+      auto constantExpr = constantMapping[i];
+      if (constantExpr.value().isNull()) {
+        // Add null column.
+        outputColumns[i] = BaseVector::createNullConstant(
+          outputType_->childAt(i), numInput, pool());
+      } else {
+        // Add constant column: gid, gpos, etc.
+        outputColumns[i] = BaseVector::createConstant(
+          constantExpr.type(),
+          constantExpr.value(),
+          numInput,
+          pool());
+      }
+    } else {
+      outputColumns[i] = input_->childAt(projectMapping[i]);
+    }
+  }
+
+  ++projectSetIndex_;
+  if (projectSetIndex_ == projectMappings_.size()) {
+    projectSetIndex_ = 0;
+    input_ = nullptr;
+  }
+
+  return std::make_shared<RowVector>(
+      pool(), outputType_, nullptr, numInput, std::move(outputColumns));
+}
+
+} // namespace facebook::velox::exec

--- a/velox/exec/Expand.h
+++ b/velox/exec/Expand.h
@@ -19,6 +19,8 @@
 
 namespace facebook::velox::exec {
 
+using ConstantTypedExprPtr = std::shared_ptr<const core::ConstantTypedExpr>;
+
 class Expand : public Operator {
  public:
   Expand(
@@ -48,7 +50,7 @@ class Expand : public Operator {
 
   std::vector<std::vector<column_index_t>> projectMappings_;
 
-  std::vector<std::vector<core::ConstantTypedExpr>> constantMappings_;
+  std::vector<std::vector<ConstantTypedExprPtr>> constantMappings_;
 
   /// 'getOutput()' returns 'input_' for one grouping set at a time.
   /// 'groupingSetIndex_' contains the index of the grouping set to output in

--- a/velox/exec/Expand.h
+++ b/velox/exec/Expand.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+#include "velox/core/Expressions.h"
+#include "velox/exec/Operator.h"
+
+namespace facebook::velox::exec {
+
+class Expand : public Operator {
+ public:
+  Expand(
+      int32_t operatorId,
+      DriverCtx* driverCtx,
+      const std::shared_ptr<const core::ExpandNode>& expandNode);
+
+  bool needsInput() const override;
+
+  void addInput(RowVectorPtr input) override;
+
+  RowVectorPtr getOutput() override;
+
+  BlockingReason isBlocked(ContinueFuture* /*future*/) override {
+    return BlockingReason::kNotBlocked;
+  }
+
+  bool isFinished() override {
+    return finished_ || (noMoreInput_ && input_ == nullptr);
+  }
+
+ private:
+  static constexpr column_index_t kUnMapedProject =
+      std::numeric_limits<column_index_t>::max();
+
+  bool finished_{false};
+
+  std::vector<std::vector<column_index_t>> projectMappings_;
+
+  std::vector<std::vector<core::ConstantTypedExpr>> constantMappings_;
+
+  /// 'getOutput()' returns 'input_' for one grouping set at a time.
+  /// 'groupingSetIndex_' contains the index of the grouping set to output in
+  /// the next 'getOutput' call. This index is used to generate groupId column
+  /// and lookup the input-to-output column mappings in the
+  /// projectMappings_.
+  int32_t projectSetIndex_{0};
+};
+} // namespace facebook::velox::exec

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -32,6 +32,7 @@
 #include "velox/exec/MergeJoin.h"
 #include "velox/exec/OrderBy.h"
 #include "velox/exec/PartitionedOutput.h"
+#include "velox/exec/Expand.h"
 #include "velox/exec/StreamingAggregation.h"
 #include "velox/exec/TableScan.h"
 #include "velox/exec/TableWriter.h"
@@ -402,6 +403,11 @@ std::shared_ptr<Driver> DriverFactory::createDriver(
         operators.push_back(
             std::make_unique<HashAggregation>(id, ctx.get(), aggregationNode));
       }
+    } else if (
+        auto expandNode =
+            std::dynamic_pointer_cast<const core::ExpandNode>(planNode)) {
+      operators.push_back(
+          std::make_unique<Expand>(id, ctx.get(), expandNode));
     } else if (
         auto groupIdNode =
             std::dynamic_pointer_cast<const core::GroupIdNode>(planNode)) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1248,6 +1248,101 @@ TEST_F(AggregationTest, groupingSets) {
       "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
 }
 
+TEST_F(AggregationTest, groupingSetsByExpand) {
+  vector_size_t size = 1'000;
+  auto data = makeRowVector(
+      {"k1", "k2", "a", "b"},
+      {
+          makeFlatVector<int64_t>(size, [](auto row) { return row % 11; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row % 17; }),
+          makeFlatVector<int64_t>(size, [](auto row) { return row; }),
+          makeFlatVector<StringView>(
+              size,
+              [](auto row) {
+                auto str = std::string(row % 12, 'x');
+                return StringView(str);
+              }),
+      });
+
+  createDuckDbTable({data});
+  // Compute a subset of aggregates per grouping set by using masks based on
+  // group_id column.
+  auto plan = PlanBuilder()
+             .values({data})
+             .expand({{"k1", "", "a", "b", "0"}, {"", "k2", "a", "b", "1"}})
+             .project(
+                 {"k1",
+                  "k2",
+                  "group_id_0",
+                  "a",
+                  "b",
+                  "group_id_0 = 0 as mask_a",
+                  "group_id_0 = 1 as mask_b"})
+             .singleAggregation(
+                 {"k1", "k2", "group_id_0"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"},
+                 {"", "mask_a", "mask_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, null, count(1), sum(a), null FROM tmp GROUP BY k1 "
+      "UNION ALL "
+      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");
+
+  // Cube.
+  plan = PlanBuilder()
+             .values({data})
+             .expand({
+                {"k1", "k2", "a", "b", "0"},
+                {"k1", "", "a", "b", "1"},
+                {"", "k2", "a", "b", "2"},
+                {"", "", "a", "b", "3"},})
+             .singleAggregation(
+                 {"k1", "k2", "group_id_0"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY CUBE (k1, k2)");
+
+  // Rollup.
+  plan = PlanBuilder()
+             .values({data})
+             .expand({
+                {"k1", "k2", "a", "b", "0"},
+                {"k1", "", "a", "b", "1"},
+                {"", "", "a", "b", "2"}})
+             .singleAggregation(
+                 {"k1", "k2", "group_id_0"},
+                 {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+             .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+             .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY ROLLUP (k1, k2)");
+  plan =
+      PlanBuilder()
+          .values({data})
+          .expand({
+                {"k1", "", "a", "b", "0", "0"},
+                {"k1", "", "a", "b", "0", "1"},
+                {"", "k2", "a", "b", "1", "2"}})
+          .singleAggregation(
+              {"k1", "k2", "group_id_0", "group_id_1"},
+              {"count(1) as count_1", "sum(a) as sum_a", "max(b) as max_b"})
+          .project({"k1", "k2", "count_1", "sum_a", "max_b"})
+          .planNode();
+
+  assertQuery(
+      plan,
+      "SELECT k1, k2, count(1), sum(a), max(b) FROM tmp GROUP BY GROUPING SETS ((k1), (k1), (k2))");
+}
+
 TEST_F(AggregationTest, groupingSetsOutput) {
   vector_size_t size = 1'000;
   auto data = makeRowVector(

--- a/velox/exec/tests/PlanNodeToStringTest.cpp
+++ b/velox/exec/tests/PlanNodeToStringTest.cpp
@@ -233,6 +233,19 @@ TEST_F(PlanNodeToStringTest, aggregation) {
       plan->toString(true, false));
 }
 
+TEST_F(PlanNodeToStringTest, expand) {
+  auto plan = PlanBuilder()
+                  .values({data_})
+                  .expand({
+                    {"c0", "", "c2", "0"},
+                    {"", "c1", "c2", "1"}})
+                  .planNode();
+  ASSERT_EQ("-- Expand\n", plan->toString());
+  ASSERT_EQ(
+      "-- Expand[[c0, null, c2, 0], [null, c1, c2, 1]] -> c0:SMALLINT, c1:INTEGER, c2:BIGINT, group_id_0:BIGINT\n",
+      plan->toString(true, false));
+}
+
 TEST_F(PlanNodeToStringTest, groupId) {
   auto plan = PlanBuilder()
                   .values({data_})

--- a/velox/exec/tests/utils/PlanBuilder.cpp
+++ b/velox/exec/tests/utils/PlanBuilder.cpp
@@ -671,6 +671,61 @@ PlanBuilder& PlanBuilder::groupId(
   return *this;
 }
 
+PlanBuilder& PlanBuilder::expand(
+    const std::vector<std::vector<std::string>>& projectionSets) {
+  std::vector<std::vector<core::TypedExprPtr>> projectSetExprs;
+  projectSetExprs.reserve(projectionSets.size());
+  std::vector<std::string> names;
+  names.reserve(projectionSets[0].size());
+  std::vector<std::shared_ptr<const Type>> types;
+  types.reserve(projectionSets[0].size());
+  std::string groupIdPrefix = "group_id_";
+  int grouIdColCount = 0;
+  for (int i = 0; i < projectionSets[0].size(); ++i) {
+    for (int j = 0; j < projectionSets.size(); ++j) {
+      if (projectionSets[j][i] != "") {
+        if (planNode_->outputType()->containsChild(projectionSets[j][i])) {
+          names.push_back(projectionSets[j][i]);
+          types.push_back(
+            field(planNode_->outputType(), projectionSets[j][i])->type());
+        } else {
+          names.push_back(groupIdPrefix + std::to_string(grouIdColCount++));
+          types.push_back(BIGINT());
+        }
+        break;
+      }
+    }
+  }
+
+  for (const auto& projectionSet : projectionSets) {
+    std::vector<core::TypedExprPtr> projectExprs;
+    projectExprs.reserve(projectionSet.size());
+    for (int i = 0; i < projectionSet.size(); ++i) {
+      if (projectionSet[i] == "") {
+        projectExprs.push_back(
+          std::make_shared<core::ConstantTypedExpr>(
+            types[i], variant::null(types[i]->kind())));
+      } else if (planNode_->outputType()->containsChild(projectionSet[i])) {
+        projectExprs.push_back(
+          field(planNode_->outputType(), projectionSet[i]));
+      } else {
+        projectExprs.push_back(
+          std::make_shared<core::ConstantTypedExpr>(
+            BIGINT(), variant(std::stol(projectionSet[i]))));
+      }
+    }
+    projectSetExprs.push_back(projectExprs);
+  }
+
+  planNode_ = std::make_shared<core::ExpandNode>(
+      nextPlanNodeId(),
+      projectSetExprs,
+      std::move(names),
+      planNode_);
+
+  return *this;
+}
+
 PlanBuilder& PlanBuilder::localMerge(
     const std::vector<std::string>& keys,
     std::vector<core::PlanNodePtr> sources) {

--- a/velox/exec/tests/utils/PlanBuilder.h
+++ b/velox/exec/tests/utils/PlanBuilder.h
@@ -449,6 +449,9 @@ class PlanBuilder {
       const std::vector<std::string>& aggregationInputs,
       std::string groupIdName = "group_id");
 
+  PlanBuilder& expand(
+      const std::vector<std::vector<std::string>>& projectionSets);
+
   /// Add a LocalMergeNode using specified ORDER BY clauses.
   ///
   /// For example,

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -49,8 +49,13 @@ class SubstraitVeloxPlanConverter {
       memory::MemoryPool* pool,
       bool validationMode = false)
       : pool_(pool), validationMode_(validationMode) {}
+
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& sExpand);
+
+  /// Used to convert Substrait GroupIdRel into Velox PlanNode,
+  /// this should be removed.
+  core::PlanNodePtr toVeloxPlan(const ::substrait::GroupIdRel& sGroupId);
 
   /// Used to convert Substrait SortRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::WindowRel& sWindow);

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -53,10 +53,6 @@ class SubstraitVeloxPlanConverter {
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& sExpand);
 
-  /// Used to convert Substrait GroupIdRel into Velox PlanNode,
-  /// this should be removed.
-  core::PlanNodePtr toVeloxPlan(const ::substrait::GroupIdRel& sGroupId);
-
   /// Used to convert Substrait SortRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::WindowRel& sWindow);
 

--- a/velox/substrait/SubstraitToVeloxPlan.h
+++ b/velox/substrait/SubstraitToVeloxPlan.h
@@ -49,7 +49,6 @@ class SubstraitVeloxPlanConverter {
       memory::MemoryPool* pool,
       bool validationMode = false)
       : pool_(pool), validationMode_(validationMode) {}
-
   /// Used to convert Substrait ExpandRel into Velox PlanNode.
   core::PlanNodePtr toVeloxPlan(const ::substrait::ExpandRel& sExpand);
 

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -228,12 +228,6 @@ bool SubstraitToVeloxPlanValidator::validate(
                 << err.message();
       return false;
     }
-    
-  }
-
-  if (sExpand.projections_size() < 2) {
-    LOG(INFO) << "SparkExpandNode requires two or more projection sets." << std::to_string(sExpand.projections_size());
-    return false;
   }
 
   return true;

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -169,11 +169,9 @@ bool SubstraitToVeloxPlanValidator::validate(
 
 bool SubstraitToVeloxPlanValidator::validate(
     const ::substrait::ExpandRel& expandRel) {
-  
   if (expandRel.has_input() && !validate(expandRel.input())) {
     return false;
   }
-  
   RowTypePtr rowType = nullptr;
   // Get and validate the input types from extension.
   if (expandRel.has_advanced_extension()) {

--- a/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -33,7 +33,7 @@ class SubstraitToVeloxPlanValidator {
   bool validate(const ::substrait::FetchRel& fetchRel);
 
   /// Used to validate whether the computing of this Expand is supported.
-  bool validate(const ::substrait::ExpandRel& sExpand);
+  bool validate(const ::substrait::ExpandRel& expandRel);
 
   /// Used to validate whether the computing of this Sort is supported.
   bool validate(const ::substrait::SortRel& sortRel);

--- a/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -35,9 +35,6 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Expand is supported.
   bool validate(const ::substrait::ExpandRel& sExpand);
 
-  /// Used to validate whether the computing of this GroupId is supported.
-  bool validate(const ::substrait::GroupIdRel& sGroupId);
-
   /// Used to validate whether the computing of this Sort is supported.
   bool validate(const ::substrait::SortRel& sortRel);
 

--- a/velox/substrait/SubstraitToVeloxPlanValidator.h
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.h
@@ -32,8 +32,11 @@ class SubstraitToVeloxPlanValidator {
   /// Used to validate whether the computing of this Limit is supported.
   bool validate(const ::substrait::FetchRel& fetchRel);
 
-  /// Used to validate whether the computing of this Sort is supported.
-  bool validate(const ::substrait::ExpandRel& expandRel);
+  /// Used to validate whether the computing of this Expand is supported.
+  bool validate(const ::substrait::ExpandRel& sExpand);
+
+  /// Used to validate whether the computing of this GroupId is supported.
+  bool validate(const ::substrait::GroupIdRel& sGroupId);
 
   /// Used to validate whether the computing of this Sort is supported.
   bool validate(const ::substrait::SortRel& sortRel);

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -355,35 +355,33 @@ message ExchangeRel {
   }
 }
 
-message GroupIdRel {
-  RelCommon common = 1;
-  Rel input = 2;
-
-  repeated Expression aggregate_expressions = 3;
-
-  // A list of expression grouping that the aggregation measured should be calculated for.
-  repeated GroupSets groupings = 4;
-
-  message GroupSets {
-    repeated Expression groupSets_expressions = 1;
-  }
-
-  string group_name = 5;
-
-  substrait.extensions.AdvancedExtension advanced_extension = 10;
-}
-
+// Duplicates records, possibly switching output expressions between each duplicate.
+// Default output is all of the fields declared followed by one int64 field that contains the
+// duplicate_id which is a zero-index ordinal of which duplicate of the original record this
+// corresponds to.
 message ExpandRel {
   RelCommon common = 1;
   Rel input = 2;
+  repeated ExpandField fields = 4;
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
 
-  repeated ProjectionSets projections = 3;
+  message ExpandField {
+    oneof field_type {
+      // Field that switches output based on which duplicate_id we're outputting
+      SwitchingField switching_field = 2;
 
-  message ProjectionSets {
-    repeated Expression projectionSets_expressions = 1;
+      // Field that outputs the same value no matter which duplicate_id we're on.
+      Expression consistent_field = 3;
+    }
   }
 
-  substrait.extensions.AdvancedExtension advanced_extension = 10;
+  message SwitchingField {
+    // Array that contains an expression to output per duplicate_id
+    // each `switching_field` must have the same number of expressions
+    // all expressions within a switching field be the same type class but can differ in nullability.
+    // this column will be nullable if any of the expressions are nullable.
+    repeated Expression duplicates = 1;
+  }
 }
 
 // A relation with output field names.
@@ -414,9 +412,8 @@ message Rel {
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
-    GroupIdRel group_id = 15;
+    ExpandRel expand = 15;
     WindowRel window = 16;
-    ExpandRel expand = 18;
   }
 }
 

--- a/velox/substrait/proto/substrait/algebra.proto
+++ b/velox/substrait/proto/substrait/algebra.proto
@@ -355,7 +355,7 @@ message ExchangeRel {
   }
 }
 
-message ExpandRel {
+message GroupIdRel {
   RelCommon common = 1;
   Rel input = 2;
 
@@ -369,6 +369,19 @@ message ExpandRel {
   }
 
   string group_name = 5;
+
+  substrait.extensions.AdvancedExtension advanced_extension = 10;
+}
+
+message ExpandRel {
+  RelCommon common = 1;
+  Rel input = 2;
+
+  repeated ProjectionSets projections = 3;
+
+  message ProjectionSets {
+    repeated Expression projectionSets_expressions = 1;
+  }
 
   substrait.extensions.AdvancedExtension advanced_extension = 10;
 }
@@ -401,8 +414,9 @@ message Rel {
     //Physical relations
     HashJoinRel hash_join = 13;
     MergeJoinRel merge_join = 14;
-    ExpandRel expand = 15;
+    GroupIdRel group_id = 15;
     WindowRel window = 16;
+    ExpandRel expand = 18;
   }
 }
 


### PR DESCRIPTION
Add expand op in velox.
This op is different from group id, which accepts projection sets and do the projection. This aligns spark ExpandExec's behavior. We don't need to do the columns' mapping in gluten side.