### PR TITLE
CI: enable unit tests with container

### DIFF
--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -26,38 +26,7 @@ jobs:
           ./scripts/setup-ubuntu.sh 
           ./scripts/setup-adapters.sh 
           make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
-          # disable failed tests temporary
-          # disable failed tests temporary, will need to restore if fixed
-          rm -f ./_build/debug/velox/type/tests/velox_type_test
-          rm -f ./_build/debug/velox/dwio/common/tests/velox_dwio_common_test
-          rm -f ./_build/debug/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test
-          rm -f ./_build/debug/velox/dwio/parquet/tests/reader/velox_parquet_e2e_filter_test
-          rm -f ./_build/debug/velox/functions/prestosql/window/tests/velox_windows_rank_test
-          rm -f ./_build/debug/velox/functions/prestosql/aggregates/tests/velox_aggregates_test
-          rm -f ./_build/debug/velox/functions/prestosql/tests/velox_functions_test
-          rm -f ./_build/debug/velox/functions/sparksql/aggregates/tests/velox_functions_spark_aggregates_test
-          rm -f ./_build/debug/velox/functions/sparksql/tests/velox_functions_spark_test
-          rm -f ./_build/debug/velox/connectors/hive/tests/velox_hive_connector_test
-          rm -f ./_build/debug/velox/exec/tests/velox_exec_test
-          rm -f ./_build/debug/velox/substrait/tests/velox_plan_conversion_test
-          rm -f ./_build/debug/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
-          rm -f ./_build/debug/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
-          rm ./_build/release/velox/type/tests/velox_type_test
-          rm ./_build/release/velox/dwio/common/tests/velox_dwio_common_test
-          rm ./_build/release/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test
-          rm ./_build/release/velox/dwio/parquet/tests/reader/velox_parquet_e2e_filter_test
-          rm ./_build/release/velox/functions/prestosql/window/tests/velox_windows_rank_test
-          rm ./_build/release/velox/functions/prestosql/aggregates/tests/velox_aggregates_test
-          rm ./_build/release/velox/functions/prestosql/tests/velox_functions_test
-          rm ./_build/release/velox/functions/sparksql/aggregates/tests/velox_functions_spark_aggregates_test
-          rm ./_build/release/velox/functions/sparksql/tests/velox_functions_spark_test
-          rm ./_build/release/velox/connectors/hive/tests/velox_hive_connector_test
-          rm ./_build/release/velox/exec/tests/velox_exec_test
-          rm ./_build/release/velox/substrait/tests/velox_plan_conversion_test
-          rm ./_build/release/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
-          rm ./_build/release/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
-          rm -f ./_build/debug/velox/functions/prestosql/window/tests/velox_windows_value_test
-          cd _build/release && ctest -j16 -VV --output-on-failure
+          cd _build/debug && ctest -j16 -VV -E "(velox_type_test|velox_dwio_common_test|velox_dwrf_e2e_filter_test|velox_parquet_e2e_filter_test|velox_windows_rank_test|velox_aggregates_test|velox_functions_test|velox_functions_spark_aggregates_test|velox_functions_spark_test|velox_hive_connector_test|velox_exec_test|velox_plan_conversion_test|velox_s3file_test|velox_hdfs_file_test|velox_windows_value_test)" --output-on-failure
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -21,6 +21,11 @@ jobs:
       - run: apt-get install -y libssl-dev flex libfl-dev git openjdk-8-jdk axel
       - run: apt-get install -y libz-dev
       - run: |
+          axel https://github.com/protocolbuffers/protobuf/releases/download/v21.4//protobuf-all-21.4.tar.gz
+          tar xf protobuf-all-21.4.tar.gz
+          cd protobuf-21.4/cmake
+          CFLAGS=-fPIC CXXFLAGS=-fPIC cmake .. && make -j && make install
+      - run: |
           axel https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20220526054841.0.0_amd64.deb
           dpkg -i minio_20220526054841.0.0_amd64.deb
           rm minio_20220526054841.0.0_amd64.deb

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -56,6 +56,7 @@ jobs:
           rm ./_build/release/velox/substrait/tests/velox_plan_conversion_test
           rm ./_build/release/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
           rm ./_build/release/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
+          rm -f ./_build/debug/velox/functions/prestosql/window/tests/velox_windows_value_test
           cd _build/release && ctest -j16 -VV --output-on-failure
 
   formatting-check:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,6 +24,7 @@ jobs:
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
+          ./scripts/setup-adapters.sh 
           make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
           # disable failed tests temporary
           rm ./_build/release/velox/type/tests/velox_type_test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -27,6 +27,21 @@ jobs:
           ./scripts/setup-adapters.sh 
           make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
           # disable failed tests temporary
+          # disable failed tests temporary, will need to restore if fixed
+          rm -f ./_build/debug/velox/type/tests/velox_type_test
+          rm -f ./_build/debug/velox/dwio/common/tests/velox_dwio_common_test
+          rm -f ./_build/debug/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test
+          rm -f ./_build/debug/velox/dwio/parquet/tests/reader/velox_parquet_e2e_filter_test
+          rm -f ./_build/debug/velox/functions/prestosql/window/tests/velox_windows_rank_test
+          rm -f ./_build/debug/velox/functions/prestosql/aggregates/tests/velox_aggregates_test
+          rm -f ./_build/debug/velox/functions/prestosql/tests/velox_functions_test
+          rm -f ./_build/debug/velox/functions/sparksql/aggregates/tests/velox_functions_spark_aggregates_test
+          rm -f ./_build/debug/velox/functions/sparksql/tests/velox_functions_spark_test
+          rm -f ./_build/debug/velox/connectors/hive/tests/velox_hive_connector_test
+          rm -f ./_build/debug/velox/exec/tests/velox_exec_test
+          rm -f ./_build/debug/velox/substrait/tests/velox_plan_conversion_test
+          rm -f ./_build/debug/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
+          rm -f ./_build/debug/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
           rm ./_build/release/velox/type/tests/velox_type_test
           rm ./_build/release/velox/dwio/common/tests/velox_dwio_common_test
           rm ./_build/release/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,19 +11,21 @@ jobs:
 
   velox-test:
     runs-on: self-hosted
+    container: ubuntu:22.04
     steps:
       - uses: actions/checkout@v2
-      - run: sudo apt-get update
-      - run: sudo apt-get install -y cmake ccache build-essential
-      - run: sudo apt-get install -y maven
-      - run: sudo apt-get install -y libboost-all-dev libcurl4-openssl-dev
-      - run: sudo apt-get install -y libssl-dev
-      - run: sudo apt-get install -y libz-dev
+      - run: apt-get update
+      - run: apt-get install -y cmake ccache build-essential ninja-build sudo
+      - run: apt-get install -y maven
+      - run: apt-get install -y libboost-all-dev libcurl4-openssl-dev
+      - run: apt-get install -y libssl-dev flex libfl-dev git libprotobuf-dev
+      - run: apt-get install -y libz-dev
       - name: Compile C++ unit tests
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
-          make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_ARROW=ON"
+          make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
+          cd _build/release && ctest -V --output-on-failure
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,8 +24,25 @@ jobs:
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
-          ./scripts/setup-adapters.sh 
-          make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
+          mkdir -p ~/adapter-deps/install
+          DEPENDENCY_DIR=~/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh ./scripts/setup-adapters.sh 
+          make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install
+          # disable failed tests temporary, will need to restore if fixed
+          #./_build/debug/velox/type/tests/velox_type_test
+          #./_build/debug/velox/dwio/common/tests/velox_dwio_common_test
+          #./_build/debug/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test
+          #./_build/debug/velox/dwio/parquet/tests/reader/velox_parquet_e2e_filter_test
+          #./_build/debug/velox/functions/prestosql/window/tests/velox_windows_rank_test
+          #./_build/debug/velox/functions/prestosql/aggregates/tests/velox_aggregates_test
+          #./_build/debug/velox/functions/prestosql/tests/velox_functions_test
+          #./_build/debug/velox/functions/sparksql/aggregates/tests/velox_functions_spark_aggregates_test
+          #./_build/debug/velox/functions/sparksql/tests/velox_functions_spark_test
+          #./_build/debug/velox/connectors/hive/tests/velox_hive_connector_test
+          #./_build/debug/velox/exec/tests/velox_exec_test
+          #./_build/debug/velox/substrait/tests/velox_plan_conversion_test
+          #./_build/debug/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
+          #./_build/debug/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
+          #./_build/debug/velox/functions/prestosql/window/tests/velox_windows_value_test
           cd _build/debug && ctest -j16 -VV -E "(velox_type_test|velox_dwio_common_test|velox_dwrf_e2e_filter_test|velox_parquet_e2e_filter_test|velox_windows_rank_test|velox_aggregates_test|velox_functions_test|velox_functions_spark_aggregates_test|velox_functions_spark_test|velox_hive_connector_test|velox_exec_test|velox_plan_conversion_test|velox_s3file_test|velox_hdfs_file_test|velox_windows_value_test)" --output-on-failure
 
   formatting-check:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -24,8 +24,8 @@ jobs:
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
-          make release EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
-          cd _build/release && ctest -V --output-on-failure
+          make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
+          cd _build/release && ctest -j16 -VV --output-on-failure
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
 
   velox-test:
     runs-on: self-hosted
-    container: ubuntu:20.04
+    container: ubuntu:22.04
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,8 +18,15 @@ jobs:
       - run: apt-get install -y cmake ccache build-essential ninja-build sudo
       - run: apt-get install -y maven
       - run: apt-get install -y libboost-all-dev libcurl4-openssl-dev
-      - run: apt-get install -y libssl-dev flex libfl-dev git libprotobuf-dev
+      - run: apt-get install -y libssl-dev flex libfl-dev git openjdk-8-jdk axel
       - run: apt-get install -y libz-dev
+      - run: |
+          axel https://dl.min.io/server/minio/release/linux-amd64/archive/minio_20220526054841.0.0_amd64.deb
+          dpkg -i minio_20220526054841.0.0_amd64.deb
+          rm minio_20220526054841.0.0_amd64.deb
+      - run: |
+          axel https://dlcdn.apache.org/hadoop/common/hadoop-2.10.1/hadoop-2.10.1.tar.gz
+          tar xf hadoop-2.10.1.tar.gz -C /usr/local/
       - name: Compile C++ unit tests
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
@@ -43,7 +50,12 @@ jobs:
           #./_build/debug/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
           #./_build/debug/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
           #./_build/debug/velox/functions/prestosql/window/tests/velox_windows_value_test
-          cd _build/debug && ctest -j16 -VV -E "(velox_type_test|velox_dwio_common_test|velox_dwrf_e2e_filter_test|velox_parquet_e2e_filter_test|velox_windows_rank_test|velox_aggregates_test|velox_functions_test|velox_functions_spark_aggregates_test|velox_functions_spark_test|velox_hive_connector_test|velox_exec_test|velox_plan_conversion_test|velox_s3file_test|velox_hdfs_file_test|velox_windows_value_test)" --output-on-failure
+          export JAVA_HOME=/usr/lib/jvm/java-1.8.0-openjdk-amd64/
+          export HADOOP_ROOT_LOGGER="WARN,DRFA"
+          export LIBHDFS3_CONF=$(pwd)/.circleci/hdfs-client.xml
+          export HADOOP_HOME='/usr/local/hadoop-2.10.1'
+          export PATH=~/adapter-deps/install/bin:/usr/local/hadoop-2.10.1/bin:${PATH}
+          cd _build/debug && ctest -j16 -VV -E "(velox_type_test|velox_dwio_common_test|velox_dwrf_e2e_filter_test|velox_parquet_e2e_filter_test|velox_windows_rank_test|velox_aggregates_test|velox_functions_test|velox_functions_spark_aggregates_test|velox_functions_spark_test|velox_hive_connector_test|velox_exec_test|velox_plan_conversion_test|velox_windows_value_test|velox_s3file_test)" --output-on-failure
 
   formatting-check:
     name: Formatting Check

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -25,6 +25,21 @@ jobs:
           git submodule sync --recursive && git submodule update --init --recursive
           ./scripts/setup-ubuntu.sh 
           make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_ARROW=ON"
+          # disable failed tests temporary
+          rm ./_build/release/velox/type/tests/velox_type_test
+          rm ./_build/release/velox/dwio/common/tests/velox_dwio_common_test
+          rm ./_build/release/velox/dwio/dwrf/test/velox_dwrf_e2e_filter_test
+          rm ./_build/release/velox/dwio/parquet/tests/reader/velox_parquet_e2e_filter_test
+          rm ./_build/release/velox/functions/prestosql/window/tests/velox_windows_rank_test
+          rm ./_build/release/velox/functions/prestosql/aggregates/tests/velox_aggregates_test
+          rm ./_build/release/velox/functions/prestosql/tests/velox_functions_test
+          rm ./_build/release/velox/functions/sparksql/aggregates/tests/velox_functions_spark_aggregates_test
+          rm ./_build/release/velox/functions/sparksql/tests/velox_functions_spark_test
+          rm ./_build/release/velox/connectors/hive/tests/velox_hive_connector_test
+          rm ./_build/release/velox/exec/tests/velox_exec_test
+          rm ./_build/release/velox/substrait/tests/velox_plan_conversion_test
+          rm ./_build/release/velox/connectors/hive/storage_adapters/s3fs/tests/velox_s3file_test
+          rm ./_build/release/velox/connectors/hive/storage_adapters/hdfs/tests/velox_hdfs_file_test
           cd _build/release && ctest -j16 -VV --output-on-failure
 
   formatting-check:

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -18,7 +18,7 @@ jobs:
       - run: apt-get install -y cmake ccache build-essential ninja-build sudo
       - run: apt-get install -y maven
       - run: apt-get install -y libboost-all-dev libcurl4-openssl-dev
-      - run: apt-get install -y libssl-dev flex libfl-dev git openjdk-8-jdk axel
+      - run: apt-get install -y libssl-dev flex libfl-dev git openjdk-8-jdk axel *thrift* libkrb5-dev libgsasl7-dev libuuid1 uuid-dev
       - run: apt-get install -y libz-dev
       - run: |
           axel https://github.com/protocolbuffers/protobuf/releases/download/v21.4//protobuf-all-21.4.tar.gz
@@ -35,9 +35,9 @@ jobs:
       - name: Compile C++ unit tests
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
-          ./scripts/setup-ubuntu.sh 
+          TZ=Asia/Shanghai ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && ./scripts/setup-ubuntu.sh 
           mkdir -p ~/adapter-deps/install
-          DEPENDENCY_DIR=~/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh ./scripts/setup-adapters.sh 
+          DEPENDENCY_DIR=~/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh 
           make debug EXTRA_CMAKE_FLAGS="-DVELOX_ENABLE_PARQUET=ON -DVELOX_BUILD_TESTING=ON -DVELOX_BUILD_TEST_UTILS=ON -DVELOX_ENABLE_HDFS=ON -DVELOX_ENABLE_S3=ON" AWSSDK_ROOT_DIR=~/adapter-deps/install
           # disable failed tests temporary, will need to restore if fixed
           #./_build/debug/velox/type/tests/velox_type_test

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -11,7 +11,7 @@ jobs:
 
   velox-test:
     runs-on: self-hosted
-    container: ubuntu:22.04
+    container: ubuntu:20.04
     steps:
       - uses: actions/checkout@v2
       - run: apt-get update

--- a/.github/workflows/unittest.yml
+++ b/.github/workflows/unittest.yml
@@ -14,9 +14,10 @@ jobs:
     container: ubuntu:22.04
     steps:
       - uses: actions/checkout@v2
+      - run: apt-get update && apt-get install ca-certificates -y && update-ca-certificates
+      - run: sed -i 's/http\:\/\/archive.ubuntu.com/https\:\/\/mirrors.ustc.edu.cn/g' /etc/apt/sources.list
       - run: apt-get update
       - run: apt-get install -y cmake ccache build-essential ninja-build sudo
-      - run: apt-get install -y maven
       - run: apt-get install -y libboost-all-dev libcurl4-openssl-dev
       - run: apt-get install -y libssl-dev flex libfl-dev git openjdk-8-jdk axel *thrift* libkrb5-dev libgsasl7-dev libuuid1 uuid-dev
       - run: apt-get install -y libz-dev
@@ -35,6 +36,8 @@ jobs:
       - name: Compile C++ unit tests
         run: |
           git submodule sync --recursive && git submodule update --init --recursive
+          sed -i 's/sudo apt/apt/g' ./scripts/setup-ubuntu.sh
+          sed -i 's/sudo --preserve-env apt/apt/g' ./scripts/setup-ubuntu.sh
           TZ=Asia/Shanghai ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && ./scripts/setup-ubuntu.sh 
           mkdir -p ~/adapter-deps/install
           DEPENDENCY_DIR=~/adapter-deps PROMPT_ALWAYS_RESPOND=n ./scripts/setup-adapters.sh 

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -25,7 +25,7 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
 function install_aws-sdk-cpp {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
-  local AWS_SDK_VERSION="1.11.36"
+  local AWS_SDK_VERSION="1.9.379"
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" -DCMAKE_INSTALL_PREFIX="${DEPENDENCY_DIR}/install"

--- a/scripts/setup-adapters.sh
+++ b/scripts/setup-adapters.sh
@@ -25,7 +25,7 @@ DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 
 function install_aws-sdk-cpp {
   local AWS_REPO_NAME="aws/aws-sdk-cpp"
-  local AWS_SDK_VERSION="1.9.96"
+  local AWS_SDK_VERSION="1.11.36"
 
   github_checkout $AWS_REPO_NAME $AWS_SDK_VERSION --depth 1 --recurse-submodules
   cmake_install -DCMAKE_BUILD_TYPE=Debug -DBUILD_SHARED_LIBS:BOOL=OFF -DMINIMIZE_SIZE:BOOL=ON -DENABLE_TESTING:BOOL=OFF -DBUILD_ONLY:STRING="s3;identity-management" -DCMAKE_INSTALL_PREFIX="${DEPENDENCY_DIR}/install"

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -108,7 +108,7 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_pb
   run_and_time install_folly
-  #run_and_time install_conda
+  run_and_time install_conda
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -55,7 +55,12 @@ apt install -y \
   bison \
   flex \
   tzdata \
-  wget
+  wget \
+  *thrift* \
+  libkrb5-dev \
+  libgsasl7-dev \
+  libuuid1 \
+  uuid-dev
 
 function run_and_time {
   time "$@"

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -27,9 +27,11 @@ FB_OS_VERSION=v2022.11.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
+export TZ=America/New_York
+export DEBIAN_FRONTEND=noninteractive
 
 # Install all velox and folly dependencies.
-sudo --preserve-env apt update && sudo apt install -y \
+apt install -y \
   g++ \
   cmake \
   ccache \

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -77,6 +77,11 @@ function prompt {
   ) 2> /dev/null
 }
 
+function install_pb {
+  github_checkout protocolbuffers/protobuf v3.21.4
+  cmake_install -Dprotobuf_BUILD_TESTS=OFF -DFMT_TEST=OFF
+}
+
 function install_fmt {
   github_checkout fmtlib/fmt 8.0.1
   cmake_install -DFMT_TEST=OFF
@@ -96,6 +101,7 @@ function install_conda {
 
 function install_velox_deps {
   run_and_time install_fmt
+  run_and_time install_pb
   run_and_time install_folly
   run_and_time install_conda
 }

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -103,7 +103,7 @@ function install_velox_deps {
   run_and_time install_fmt
   run_and_time install_pb
   run_and_time install_folly
-  run_and_time install_conda
+  #run_and_time install_conda
 }
 
 (return 2> /dev/null) && return # If script was sourced, don't run commands.

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -27,11 +27,9 @@ FB_OS_VERSION=v2022.11.14.00
 NPROC=$(getconf _NPROCESSORS_ONLN)
 DEPENDENCY_DIR=${DEPENDENCY_DIR:-$(pwd)}
 export CMAKE_BUILD_TYPE=Release
-export TZ=America/New_York
-export DEBIAN_FRONTEND=noninteractive
 
 # Install all velox and folly dependencies.
-apt install -y \
+sudo --preserve-env apt update && sudo apt install -y \
   g++ \
   cmake \
   ccache \
@@ -55,12 +53,7 @@ apt install -y \
   bison \
   flex \
   tzdata \
-  wget \
-  *thrift* \
-  libkrb5-dev \
-  libgsasl7-dev \
-  libuuid1 \
-  uuid-dev
+  wget
 
 function run_and_time {
   time "$@"
@@ -81,7 +74,6 @@ function prompt {
     done
   ) 2> /dev/null
 }
-
 
 function install_fmt {
   github_checkout fmtlib/fmt 8.0.1

--- a/scripts/setup-ubuntu.sh
+++ b/scripts/setup-ubuntu.sh
@@ -82,10 +82,6 @@ function prompt {
   ) 2> /dev/null
 }
 
-function install_pb {
-  github_checkout protocolbuffers/protobuf v3.21.4
-  cmake_install -Dprotobuf_BUILD_TESTS=OFF -DFMT_TEST=OFF
-}
 
 function install_fmt {
   github_checkout fmtlib/fmt 8.0.1
@@ -106,7 +102,6 @@ function install_conda {
 
 function install_velox_deps {
   run_and_time install_fmt
-  run_and_time install_pb
   run_and_time install_folly
   run_and_time install_conda
 }

--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -18,8 +18,8 @@
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
-#include "velox/vector/arrow/Bridge.h"
 #include "velox/vector/ComplexVectorStream.h"
+#include "velox/vector/arrow/Bridge.h"
 
 /// These definition should be included by user from either
 ///   1. <arrow/c/abi.h> or

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -16,7 +16,6 @@
 #include "velox/exec/LocalPlanner.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/exec/ArrowStream.h"
-#include "velox/exec/ValueStream.h"
 #include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/CallbackSink.h"
 #include "velox/exec/CrossJoinBuild.h"
@@ -39,6 +38,7 @@
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/TopN.h"
 #include "velox/exec/Unnest.h"
+#include "velox/exec/ValueStream.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/Window.h"
 


### PR DESCRIPTION
This patch tries to enable C++ unit tests, in a container. 
The failed tests are excluded temporary, will be added back in another patch.