### PR TITLE
[GLUTEN-1245] Support parquet write in velox backend

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -43,7 +43,7 @@ void Writer::write(const RowVectorPtr& data) {
             arrowProperties));
   }
 
-  PARQUET_THROW_NOT_OK(arrowWriter_->WriteTable(*table, 10000));
+  PARQUET_THROW_NOT_OK(arrowWriter_->WriteRecordBatch(*recordBatch));
 }
 
 void Writer::flush() {


### PR DESCRIPTION
Change `arrowWriter_->WriteTable()` method to `arrowWriter_->WriteRecordBatch()` in parquet writer.   `arrowWriter_->WriteRecordBatch()` do some optimization to buffer current row group, which can improve the parquet write performance.