### PR TITLE
Fix makeRowGroupSkipRangeFilter in test

### DIFF
--- a/velox/dwio/common/tests/utils/FilterGenerator.cpp
+++ b/velox/dwio/common/tests/utils/FilterGenerator.cpp
@@ -222,7 +222,7 @@ std::unique_ptr<Filter> ColumnStats<StringView>::makeRowGroupSkipRangeFilter(
     const Subfield& /*subfield*/) {
   static std::string max = kMaxString;
   return std::make_unique<velox::common::BytesRange>(
-      max, false, false, max, false, false, false);
+      max, false, false, "", false, false, false);
 }
 
 std::string FilterGenerator::specsToString(

--- a/velox/dwio/common/tests/utils/FilterGenerator.h
+++ b/velox/dwio/common/tests/utils/FilterGenerator.h
@@ -325,8 +325,11 @@ class ColumnStats : public AbstractColumnStats {
         }
       }
     }
+    int64_t value = getIntegerValue(max);
+    int64_t lower = value > 0 ? value : value * (-1);
+    int64_t upper = value > 0 ? value * (-1) : value;
     return std::make_unique<velox::common::BigintRange>(
-        getIntegerValue(max), getIntegerValue(max), false);
+        lower, upper, false);
   }
 
   // The sample size is 65536.


### PR DESCRIPTION
Setting the max value as `getIntegerValue(max)` is not enough to filter out a row group.
This issue was found in `velox_parquet_e2e_filter_test` after https://github.com/oap-project/velox/pull/207 which caused the change of Parquet metadata.