### PR TITLE
Fix velox functions test

### DIFF
--- a/velox/functions/prestosql/DateTimeFunctions.h
+++ b/velox/functions/prestosql/DateTimeFunctions.h
@@ -150,25 +150,22 @@ struct YearFunction : public InitSessionTimezone<T>,
                       public TimestampWithTimezoneSupport<T> {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
-  FOLLY_ALWAYS_INLINE int32_t getYear(const std::tm& time) {
+  FOLLY_ALWAYS_INLINE int64_t getYear(const std::tm& time) {
     return 1900 + time.tm_year;
   }
 
-  template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(
-      TInput& result,
+      int64_t& result,
       const arg_type<Timestamp>& timestamp) {
     result = getYear(getDateTime(timestamp, this->timeZone_));
   }
 
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE void call(TInput& result, const arg_type<Date>& date) {
+  FOLLY_ALWAYS_INLINE void call(int64_t& result, const arg_type<Date>& date) {
     result = getYear(getDateTime(date));
   }
 
-  template <typename TInput>
   FOLLY_ALWAYS_INLINE void call(
-      TInput& result,
+      int64_t& result,
       const arg_type<TimestampWithTimezone>& timestampWithTimezone) {
     auto timestamp = this->toTimestamp(timestampWithTimezone);
     result = getYear(getDateTime(timestamp, nullptr));

--- a/velox/functions/prestosql/StringFunctions.h
+++ b/velox/functions/prestosql/StringFunctions.h
@@ -109,13 +109,6 @@ struct SubstrFunction {
       start = numCharacters + start + 1;
     }
 
-    // Following vanilla spark semantics. When the start is 0 after adjusing
-    // start, Keep the origin input.
-    if (start <= 0) {
-      start = 1;
-      length = numCharacters;
-    }
-
     // Following Presto semantics
     if (start <= 0 || start > numCharacters) {
       result.setEmpty();

--- a/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/DateTimeFunctionsRegistration.cpp
@@ -28,9 +28,9 @@ void registerSimpleFunctions(const std::string& prefix) {
       {prefix + "to_unixtime"});
   registerFunction<FromUnixtimeFunction, Timestamp, double>(
       {prefix + "from_unixtime"});
-  registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
-  registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
-  registerFunction<YearFunction, int32_t, TimestampWithTimezone>(
+  registerFunction<YearFunction, int64_t, Timestamp>({prefix + "year"});
+  registerFunction<YearFunction, int64_t, Date>({prefix + "year"});
+  registerFunction<YearFunction, int64_t, TimestampWithTimezone>(
       {prefix + "year"});
   registerFunction<WeekFunction, int64_t, Timestamp>(
       {prefix + "week", prefix + "week_of_year"});

--- a/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
+++ b/velox/functions/prestosql/tests/ScalarFunctionRegTest.cpp
@@ -56,6 +56,7 @@ TEST_F(ScalarFunctionRegTest, prefix) {
   scalarVectorFuncMap.erase("in");
   scalarVectorFuncMap.erase("row_constructor");
   scalarVectorFuncMap.erase("is_null");
+  scalarVectorFuncMap.erase("row_constructor_with_null");
 
   for (const auto& entry : scalarVectorFuncMap) {
     EXPECT_EQ(prefix, entry.first.substr(0, prefix.size()));

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -88,10 +88,14 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "lpad"});
   registerFunction<RPadFunction, Varchar, Varchar, int32_t, Varchar>(
       {prefix + "rpad"});
-  registerFunction<SubstrFunction, Varchar, Varchar, int32_t>(
+  registerFunction<sparksql::SubstrFunction, Varchar, Varchar, int32_t>(
       {prefix + "substring"});
-  registerFunction<SubstrFunction, Varchar, Varchar, int32_t, int32_t>(
-      {prefix + "substring"});
+  registerFunction<
+      sparksql::SubstrFunction,
+      Varchar,
+      Varchar,
+      int32_t,
+      int32_t>({prefix + "substring"});
   exec::registerStatefulVectorFunction("instr", instrSignatures(), makeInstr);
   exec::registerStatefulVectorFunction(
       "length", lengthSignatures(), makeLength);

--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -429,4 +429,95 @@ struct LTrimSpaceFunction : public TrimSpaceFunctionBase<T, true, false> {};
 template <typename T>
 struct RTrimSpaceFunction : public TrimSpaceFunctionBase<T, false, true> {};
 
+/// substr(string, start) -> varchar
+///
+///     Returns the rest of string from the starting position start.
+///     Positions start with 1. A negative starting position is interpreted as
+///     being relative to the end of the string. When the starting position is
+///     0, the meaning is to refer to the first character.
+
+///
+/// substr(string, start, length) -> varchar
+///
+///     Returns a substring from string of length length from the
+///     starting position start. Positions start with 1. A negative starting
+///     position is interpreted as being relative to the end of the string.
+///     When the starting position is 0, the meaning is to refer to the
+///     first character.
+template <typename T>
+struct SubstrFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  // Results refer to strings in the first argument.
+  static constexpr int32_t reuse_strings_from_arg = 0;
+
+  // ASCII input always produces ASCII result.
+  static constexpr bool is_default_ascii_behavior = true;
+
+  FOLLY_ALWAYS_INLINE void call(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    doCall<false>(result, input, start, length);
+  }
+
+  FOLLY_ALWAYS_INLINE void callAscii(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    doCall<true>(result, input, start, length);
+  }
+
+  template <bool isAscii>
+  FOLLY_ALWAYS_INLINE void doCall(
+      out_type<Varchar>& result,
+      const arg_type<Varchar>& input,
+      int32_t start,
+      int32_t length = std::numeric_limits<int32_t>::max()) {
+    if (length <= 0) {
+      result.setEmpty();
+      return;
+    }
+    // Following Spark semantics
+    if (start == 0) {
+      start = 1;
+    }
+
+    int32_t numCharacters = stringImpl::length<isAscii>(input);
+
+    // negative starting position
+    if (start < 0) {
+      start = numCharacters + start + 1;
+    }
+
+    // Adjusting last
+    int32_t last;
+    bool lastOverflow = __builtin_add_overflow(start, length - 1, &last);
+    if (lastOverflow || last > numCharacters) {
+      last = numCharacters;
+    }
+
+    // Following Spark semantics
+    if (start <= 0) {
+      start = 1;
+    }
+
+    // Adjusting length
+    length = last - start + 1;
+    if (length <= 0) {
+      result.setEmpty();
+      return;
+    }
+
+    auto byteRange =
+        stringCore::getByteRange<isAscii>(input.data(), start, length);
+
+    // Generating output string
+    result.setNoCopy(StringView(
+        input.data() + byteRange.first, byteRange.second - byteRange.first));
+  }
+};
+
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -127,6 +127,19 @@ class StringTest : public SparkFunctionBaseTest {
     return evaluateOnce<std::string, std::string, std::string, int32_t>(
         "substring_index(c0, c1, c2)", str, delim, count);
   }
+  std::optional<std::string> substring(
+      std::optional<std::string> str,
+      std::optional<int32_t> start) {
+    return evaluateOnce<std::string>("substring(c0, c1)", str, start);
+  }
+
+  std::optional<std::string> substring(
+      std::optional<std::string> str,
+      std::optional<int32_t> start,
+      std::optional<int32_t> length) {
+    return evaluateOnce<std::string>(
+        "substring(c0, c1, c2)", str, start, length);
+  }
 };
 
 TEST_F(StringTest, Ascii) {

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -398,5 +398,40 @@ TEST_F(StringTest, rtrim) {
       "\u6574\u6570 \u6570\u636E!");
 }
 
+TEST_F(StringTest, substring) {
+  EXPECT_EQ(substring("example", 0, 2), "ex");
+  EXPECT_EQ(substring("example", 1, -1), "");
+  EXPECT_EQ(substring("example", 1, 0), "");
+  EXPECT_EQ(substring("example", 1, 2), "ex");
+  EXPECT_EQ(substring("example", 1, 7), "example");
+  EXPECT_EQ(substring("example", 1, 100), "example");
+  EXPECT_EQ(substring("example", 2, 2), "xa");
+  EXPECT_EQ(substring("example", 8, 2), "");
+  EXPECT_EQ(substring("example", -2, 2), "le");
+  EXPECT_EQ(substring("example", -7, 2), "ex");
+  EXPECT_EQ(substring("example", -8, 2), "e");
+  EXPECT_EQ(substring("example", -9, 2), "");
+  EXPECT_EQ(substring("example", -7, 7), "example");
+  EXPECT_EQ(substring("example", -9, 9), "example");
+  EXPECT_EQ(substring("example", 4, 2147483645), "mple");
+  EXPECT_EQ(substring("example", 2147483645, 4), "");
+  EXPECT_EQ(substring("example", -2147483648, 1), "");
+  EXPECT_EQ(substring("da\u6570\u636Eta", 2, 4), "a\u6570\u636Et");
+  EXPECT_EQ(substring("da\u6570\u636Eta", -3, 2), "\u636Et");
+
+  EXPECT_EQ(substring("example", 0), "example");
+  EXPECT_EQ(substring("example", 1), "example");
+  EXPECT_EQ(substring("example", 2), "xample");
+  EXPECT_EQ(substring("example", 8), "");
+  EXPECT_EQ(substring("example", 2147483647), "");
+  EXPECT_EQ(substring("example", -2), "le");
+  EXPECT_EQ(substring("example", -7), "example");
+  EXPECT_EQ(substring("example", -8), "example");
+  EXPECT_EQ(substring("example", -9), "example");
+  EXPECT_EQ(substring("example", -2147483647), "example");
+  EXPECT_EQ(substring("da\u6570\u636Eta", 3), "\u6570\u636Eta");
+  EXPECT_EQ(substring("da\u6570\u636Eta", -3), "\u636Eta");
+}
+
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
* presto getYear function return value change to int64_t.
* remove row_constructor_with_null in ScalarFunctionRegTest.cpp. because this function do not have prefix.
* introduce substring function from https://github.com/facebookincubator/velox/pull/4631. And back out presto substring function.