### PR TITLE
Improve might contain

### DIFF
--- a/velox/common/base/BloomFilter.h
+++ b/velox/common/base/BloomFilter.h
@@ -44,7 +44,7 @@ class BloomFilter {
     bits_.resize(std::max<int32_t>(4, bits::nextPowerOfTwo(capacity) / 4));
   }
 
-  bool isSet() {
+  bool isSet() const {
     return bits_.size() > 0;
   }
 

--- a/velox/functions/sparksql/MightContain.h
+++ b/velox/functions/sparksql/MightContain.h
@@ -19,6 +19,8 @@ namespace facebook::velox::functions::sparksql {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> mightContainSignatures();
 
-std::unique_ptr<exec::VectorFunction> makeMightContain();
+std::unique_ptr<exec::VectorFunction> makeMightContain(
+    const std::string& name,
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
 
 } // namespace facebook::velox::functions::sparksql

--- a/velox/functions/sparksql/MightContain.h
+++ b/velox/functions/sparksql/MightContain.h
@@ -19,7 +19,7 @@ namespace facebook::velox::functions::sparksql {
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> mightContainSignatures();
 
-std::unique_ptr<exec::VectorFunction> makeMightContain(
+std::shared_ptr<exec::VectorFunction> makeMightContain(
     const std::string& name,
     const std::vector<exec::VectorFunctionArg>& inputArgs);
 

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -173,8 +173,8 @@ void registerFunctions(const std::string& prefix) {
   exec::registerStatefulVectorFunction(
       prefix + "abs", absSignatures(), makeAbs);
   // Register bloom filter function
-  exec::registerVectorFunction(
-      prefix + "might_contain", mightContainSignatures(), makeMightContain());
+  exec::registerStatefulVectorFunction(
+      prefix + "might_contain", mightContainSignatures(), makeMightContain);
   // Register date functions.
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});


### PR DESCRIPTION
`BloomFilter.merge` is called for every row batch in `might_contain` function. We can improve it by leveraging stateful vector function, which can keep some state many runs of vector batches in the query so they can amortize the initialization cost. For `might_contain` function, `BloomFilter.merge` can only be called during the initialization phase.
Query93
Before:
![image](https://user-images.githubusercontent.com/10524738/234636822-62f9e68a-96db-473d-be4e-4749ba8bea17.png)

After:
![image](https://user-images.githubusercontent.com/10524738/234636966-4bedeb25-c417-4c68-9157-ffc5879cc853.png)
