### PR TITLE
Pass Velox functions spark test

### DIFF
--- a/velox/core/PlanNode.h
+++ b/velox/core/PlanNode.h
@@ -18,8 +18,8 @@
 #include "velox/connectors/Connector.h"
 #include "velox/core/Expressions.h"
 #include "velox/core/QueryConfig.h"
-#include "velox/vector/arrow/Bridge.h"
 #include "velox/vector/ComplexVectorStream.h"
+#include "velox/vector/arrow/Bridge.h"
 
 /// These definition should be included by user from either
 ///   1. <arrow/c/abi.h> or

--- a/velox/exec/LocalPlanner.cpp
+++ b/velox/exec/LocalPlanner.cpp
@@ -16,7 +16,6 @@
 #include "velox/exec/LocalPlanner.h"
 #include "velox/core/PlanFragment.h"
 #include "velox/exec/ArrowStream.h"
-#include "velox/exec/ValueStream.h"
 #include "velox/exec/AssignUniqueId.h"
 #include "velox/exec/CallbackSink.h"
 #include "velox/exec/CrossJoinBuild.h"
@@ -39,6 +38,7 @@
 #include "velox/exec/TableWriter.h"
 #include "velox/exec/TopN.h"
 #include "velox/exec/Unnest.h"
+#include "velox/exec/ValueStream.h"
 #include "velox/exec/Values.h"
 #include "velox/exec/Window.h"
 

--- a/velox/functions/sparksql/Arithmetic.h
+++ b/velox/functions/sparksql/Arithmetic.h
@@ -25,25 +25,6 @@
 namespace facebook::velox::functions::sparksql {
 
 template <typename T>
-struct PModIntFunction {
-  template <typename TInput>
-  FOLLY_ALWAYS_INLINE bool call(TInput& result, const TInput a, const TInput n)
-#if defined(__has_feature)
-#if __has_feature(__address_sanitizer__)
-      __attribute__((__no_sanitize__("signed-integer-overflow")))
-#endif
-#endif
-  {
-    if (UNLIKELY(n == 0)) {
-      return false;
-    }
-    TInput r = a % n;
-    result = (r > 0) ? r : (r + n) % n;
-    return true;
-  }
-};
-
-template <typename T>
 struct PModFloatFunction {
   template <typename TInput>
   FOLLY_ALWAYS_INLINE bool

--- a/velox/functions/sparksql/Register.cpp
+++ b/velox/functions/sparksql/Register.cpp
@@ -196,52 +196,52 @@ void registerFunctions(const std::string& prefix) {
       {prefix + "millisecond"});
   registerFunction<MillisecondFunction, int32_t, Timestamp>(
       {prefix + "millisecond"});
-  registerFunction<MillisecondFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "millisecond"});
+  //   registerFunction<MillisecondFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "millisecond"});
   registerFunction<SecondFunction, int32_t, Date>({prefix + "second"});
   registerFunction<SecondFunction, int32_t, Timestamp>({prefix + "second"});
-  registerFunction<SecondFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "second"});
+  //   registerFunction<SecondFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "second"});
   registerFunction<MinuteFunction, int32_t, Date>({prefix + "minute"});
   registerFunction<MinuteFunction, int32_t, Timestamp>({prefix + "minute"});
-  registerFunction<MinuteFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "minute"});
+  //   registerFunction<MinuteFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "minute"});
   registerFunction<HourFunction, int32_t, Date>({prefix + "hour"});
   registerFunction<HourFunction, int32_t, Timestamp>({prefix + "hour"});
-  registerFunction<HourFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "hour"});
+  //   registerFunction<HourFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "hour"});
   registerFunction<DayFunction, int32_t, Date>(
       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayFunction, int32_t, Timestamp>(
       {prefix + "day", prefix + "day_of_month"});
-  registerFunction<DayFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "day", prefix + "day_of_month"});
+  //   registerFunction<DayFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "day", prefix + "day_of_month"});
   registerFunction<DayOfWeekFunction, int32_t, Date>({prefix + "day_of_week"});
   registerFunction<DayOfWeekFunction, int32_t, Timestamp>(
       {prefix + "day_of_week"});
-  registerFunction<DayOfWeekFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "day_of_week"});
+  //   registerFunction<DayOfWeekFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "day_of_week"});
   registerFunction<DayOfYearFunction, int32_t, Date>({prefix + "day_of_year"});
   registerFunction<DayOfYearFunction, int32_t, Timestamp>(
       {prefix + "day_of_year"});
-  registerFunction<DayOfYearFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "day_of_year"});
+  //   registerFunction<DayOfYearFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "day_of_year"});
   registerFunction<MonthFunction, int32_t, Date>({prefix + "month"});
   registerFunction<MonthFunction, int32_t, Timestamp>({prefix + "month"});
-  registerFunction<MonthFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "month"});
+  //   registerFunction<MonthFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "month"});
   registerFunction<QuarterFunction, int32_t, Date>({prefix + "quarter"});
   registerFunction<QuarterFunction, int32_t, Timestamp>({prefix + "quarter"});
-  registerFunction<QuarterFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "quarter"});
+  //   registerFunction<QuarterFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "quarter"});
   registerFunction<YearFunction, int32_t, Date>({prefix + "year"});
   registerFunction<YearFunction, int32_t, Timestamp>({prefix + "year"});
   registerFunction<YearOfWeekFunction, int32_t, Date>(
       {prefix + "year_of_week"});
   registerFunction<YearOfWeekFunction, int32_t, Timestamp>(
       {prefix + "year_of_week"});
-  registerFunction<YearOfWeekFunction, int32_t, TimestampWithTimezone>(
-      {prefix + "year_of_week"});
+  //   registerFunction<YearOfWeekFunction, int32_t, TimestampWithTimezone>(
+  //       {prefix + "year_of_week"});
   registerFunction<DateAddFunction, Date, Date, int32_t>({"date_add"});
   registerFunction<DateAddFunction, Date, Date, int16_t>({"date_add"});
   registerFunction<DateAddFunction, Date, Date, int8_t>({"date_add"});

--- a/velox/functions/sparksql/RegisterArithmetic.cpp
+++ b/velox/functions/sparksql/RegisterArithmetic.cpp
@@ -32,7 +32,7 @@ void registerArithmeticFunctions(const std::string& prefix) {
   // Math functions.
   registerUnaryNumeric<AbsFunction>({prefix + "abs"});
   registerFunction<ExpFunction, double, double>({prefix + "exp"});
-  registerBinaryIntegral<PModIntFunction>({prefix + "pmod"});
+  registerBinaryIntegral<PModFunction>({prefix + "pmod"});
   registerBinaryFloatingPoint<PModFloatFunction>({prefix + "pmod"});
   registerFunction<PowerFunction, double, double, double>({prefix + "power"});
   registerUnaryNumeric<RoundFunction>({prefix + "round"});

--- a/velox/functions/sparksql/tests/DateTimeTest.cpp
+++ b/velox/functions/sparksql/tests/DateTimeTest.cpp
@@ -246,34 +246,34 @@ TEST_F(DateTimeTest, yearDate) {
   EXPECT_EQ(1920, year(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, yearTimestampWithTimezone) {
-  EXPECT_EQ(
-      1969,
-      evaluateWithTimestampWithTimezone<int32_t>("year(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1970,
-      evaluateWithTimestampWithTimezone<int32_t>("year(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      1973,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      1966,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      2001,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      1938,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, yearTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       1969,
+//       evaluateWithTimestampWithTimezone<int32_t>("year(c0)", 0, "-01:00"));
+//   EXPECT_EQ(
+//       1970,
+//       evaluateWithTimestampWithTimezone<int32_t>("year(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       1973,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       1966,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       2001,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       1938,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, quarter) {
   const auto quarter = [&](std::optional<Timestamp> date) {
@@ -312,34 +312,36 @@ TEST_F(DateTimeTest, quarterDate) {
   EXPECT_EQ(1, quarter(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, quarterTimestampWithTimezone) {
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>("quarter(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1,
-      evaluateWithTimestampWithTimezone<int32_t>("quarter(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "quarter(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      1,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "quarter(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      2,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "quarter(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      3,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "quarter(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "quarter(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, quarterTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>("quarter(c0)", 0,
+//       "-01:00"));
+//   EXPECT_EQ(
+//       1,
+//       evaluateWithTimestampWithTimezone<int32_t>("quarter(c0)", 0,
+//       "+00:00"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "quarter(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       1,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "quarter(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       2,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "quarter(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       3,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "quarter(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "quarter(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, month) {
   const auto month = [&](std::optional<Timestamp> date) {
@@ -377,32 +379,34 @@ TEST_F(DateTimeTest, monthDate) {
   EXPECT_EQ(1, month(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, monthTimestampWithTimezone) {
-  EXPECT_EQ(
-      12, evaluateWithTimestampWithTimezone<int32_t>("month(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1, evaluateWithTimestampWithTimezone<int32_t>("month(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      11,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "month(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      2,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "month(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "month(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      9,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "month(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "month(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, monthTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       12, evaluateWithTimestampWithTimezone<int32_t>("month(c0)", 0,
+//       "-01:00"));
+//   EXPECT_EQ(
+//       1, evaluateWithTimestampWithTimezone<int32_t>("month(c0)", 0,
+//       "+00:00"));
+//   EXPECT_EQ(
+//       11,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "month(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       2,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "month(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "month(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       9,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "month(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "month(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, hour) {
   const auto hour = [&](std::optional<Timestamp> date) {
@@ -429,44 +433,44 @@ TEST_F(DateTimeTest, hour) {
   EXPECT_EQ(8, hour(Timestamp(998423705, 321000000)));
 }
 
-TEST_F(DateTimeTest, hourTimestampWithTimezone) {
-  EXPECT_EQ(
-      20,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 998423705000, "+01:00"));
-  EXPECT_EQ(
-      12,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 41028000, "+01:00"));
-  EXPECT_EQ(
-      13,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 41028000, "+02:00"));
-  EXPECT_EQ(
-      14,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 41028000, "+03:00"));
-  EXPECT_EQ(
-      8,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 41028000, "-03:00"));
-  EXPECT_EQ(
-      1,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", 41028000, "+14:00"));
-  EXPECT_EQ(
-      9,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", -100000, "-14:00"));
-  EXPECT_EQ(
-      2,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", -41028000, "+14:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "hour(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, hourTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       20,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 998423705000, "+01:00"));
+//   EXPECT_EQ(
+//       12,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 41028000, "+01:00"));
+//   EXPECT_EQ(
+//       13,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 41028000, "+02:00"));
+//   EXPECT_EQ(
+//       14,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 41028000, "+03:00"));
+//   EXPECT_EQ(
+//       8,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 41028000, "-03:00"));
+//   EXPECT_EQ(
+//       1,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", 41028000, "+14:00"));
+//   EXPECT_EQ(
+//       9,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", -100000, "-14:00"));
+//   EXPECT_EQ(
+//       2,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", -41028000, "+14:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "hour(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, hourDate) {
   const auto hour = [&](std::optional<Date> date) {
@@ -517,36 +521,36 @@ TEST_F(DateTimeTest, dayOfMonthDate) {
   EXPECT_EQ(2, day(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, dayOfMonthTimestampWithTimezone) {
-  EXPECT_EQ(
-      31,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      30,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      2,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      18,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      14,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_month(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, dayOfMonthTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       31,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", 0, "-01:00"));
+//   EXPECT_EQ(
+//       1,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       30,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       2,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       18,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       14,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_month(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, dayOfWeek) {
   const auto day = [&](std::optional<Timestamp> date) {
@@ -590,36 +594,36 @@ TEST_F(DateTimeTest, dayOfWeekDate) {
   EXPECT_EQ(6, day(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, dayOfWeekTimestampWithTimezone) {
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      5,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      6,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_week(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, dayOfWeekTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", 0, "-01:00"));
+//   EXPECT_EQ(
+//       5,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       6,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_week(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, dayOfYear) {
   const auto day = [&](std::optional<Timestamp> date) {
@@ -657,36 +661,36 @@ TEST_F(DateTimeTest, dayOfYearDate) {
   EXPECT_EQ(2, day(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, dayOfYearTimestampWithTimezone) {
-  EXPECT_EQ(
-      365,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      334,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      33,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      108,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      257,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "day_of_year(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, dayOfYearTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       365,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", 0, "-01:00"));
+//   EXPECT_EQ(
+//       1,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       334,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       33,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       108,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       257,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "day_of_year(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, yearOfWeek) {
   const auto yow = [&](std::optional<Timestamp> date) {
@@ -730,36 +734,36 @@ TEST_F(DateTimeTest, yearOfWeekDate) {
   EXPECT_EQ(2021, yow(Date(18900)));
 }
 
-TEST_F(DateTimeTest, yearOfWeekTimestampWithTimezone) {
-  EXPECT_EQ(
-      1970,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", 0, "-01:00"));
-  EXPECT_EQ(
-      1970,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      1973,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", 123456789000, "+14:00"));
-  EXPECT_EQ(
-      1966,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", -123456789000, "+03:00"));
-  EXPECT_EQ(
-      2001,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", 987654321000, "-07:00"));
-  EXPECT_EQ(
-      1938,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", -987654321000, "-13:00"));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "year_of_week(c0)", std::nullopt, std::nullopt));
-}
+// TEST_F(DateTimeTest, yearOfWeekTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       1970,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", 0, "-01:00"));
+//   EXPECT_EQ(
+//       1970,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       1973,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", 123456789000, "+14:00"));
+//   EXPECT_EQ(
+//       1966,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", -123456789000, "+03:00"));
+//   EXPECT_EQ(
+//       2001,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", 987654321000, "-07:00"));
+//   EXPECT_EQ(
+//       1938,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", -987654321000, "-13:00"));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "year_of_week(c0)", std::nullopt, std::nullopt));
+// }
 
 TEST_F(DateTimeTest, minute) {
   const auto minute = [&](std::optional<Timestamp> date) {
@@ -797,45 +801,46 @@ TEST_F(DateTimeTest, minuteDate) {
   EXPECT_EQ(0, minute(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, minuteTimestampWithTimezone) {
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", std::nullopt, std::nullopt));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", std::nullopt, "Asia/Kolkata"));
-  EXPECT_EQ(
-      0, evaluateWithTimestampWithTimezone<int32_t>("minute(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      30,
-      evaluateWithTimestampWithTimezone<int32_t>("minute(c0)", 0, "+05:30"));
-  EXPECT_EQ(
-      6,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", 4000000000000, "+00:00"));
-  EXPECT_EQ(
-      36,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", 4000000000000, "+05:30"));
-  EXPECT_EQ(
-      4,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", 998474645000, "+00:00"));
-  EXPECT_EQ(
-      34,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", 998474645000, "+05:30"));
-  EXPECT_EQ(
-      59,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", -1000, "+00:00"));
-  EXPECT_EQ(
-      29,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "minute(c0)", -1000, "+05:30"));
-}
+// TEST_F(DateTimeTest, minuteTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", std::nullopt, std::nullopt));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", std::nullopt, "Asia/Kolkata"));
+//   EXPECT_EQ(
+//       0, evaluateWithTimestampWithTimezone<int32_t>("minute(c0)", 0,
+//       "+00:00"));
+//   EXPECT_EQ(
+//       30,
+//       evaluateWithTimestampWithTimezone<int32_t>("minute(c0)", 0, "+05:30"));
+//   EXPECT_EQ(
+//       6,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", 4000000000000, "+00:00"));
+//   EXPECT_EQ(
+//       36,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", 4000000000000, "+05:30"));
+//   EXPECT_EQ(
+//       4,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", 998474645000, "+00:00"));
+//   EXPECT_EQ(
+//       34,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", 998474645000, "+05:30"));
+//   EXPECT_EQ(
+//       59,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", -1000, "+00:00"));
+//   EXPECT_EQ(
+//       29,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "minute(c0)", -1000, "+05:30"));
+// }
 
 TEST_F(DateTimeTest, second) {
   const auto second = [&](std::optional<Timestamp> timestamp) {
@@ -861,36 +866,38 @@ TEST_F(DateTimeTest, secondDate) {
   EXPECT_EQ(0, second(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, secondTimestampWithTimezone) {
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", std::nullopt, std::nullopt));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", std::nullopt, "+05:30"));
-  EXPECT_EQ(
-      0, evaluateWithTimestampWithTimezone<int32_t>("second(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      0, evaluateWithTimestampWithTimezone<int32_t>("second(c0)", 0, "+05:30"));
-  EXPECT_EQ(
-      40,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", 4000000000000, "+00:00"));
-  EXPECT_EQ(
-      40,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", 4000000000000, "+05:30"));
-  EXPECT_EQ(
-      59,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", -1000, "+00:00"));
-  EXPECT_EQ(
-      59,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "second(c0)", -1000, "+05:30"));
-}
+// TEST_F(DateTimeTest, secondTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", std::nullopt, std::nullopt));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", std::nullopt, "+05:30"));
+//   EXPECT_EQ(
+//       0, evaluateWithTimestampWithTimezone<int32_t>("second(c0)", 0,
+//       "+00:00"));
+//   EXPECT_EQ(
+//       0, evaluateWithTimestampWithTimezone<int32_t>("second(c0)", 0,
+//       "+05:30"));
+//   EXPECT_EQ(
+//       40,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", 4000000000000, "+00:00"));
+//   EXPECT_EQ(
+//       40,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", 4000000000000, "+05:30"));
+//   EXPECT_EQ(
+//       59,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", -1000, "+00:00"));
+//   EXPECT_EQ(
+//       59,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "second(c0)", -1000, "+05:30"));
+// }
 
 TEST_F(DateTimeTest, millisecond) {
   const auto millisecond = [&](std::optional<Timestamp> timestamp) {
@@ -916,40 +923,40 @@ TEST_F(DateTimeTest, millisecondDate) {
   EXPECT_EQ(0, millisecond(Date(-18262)));
 }
 
-TEST_F(DateTimeTest, millisecondTimestampWithTimezone) {
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", std::nullopt, std::nullopt));
-  EXPECT_EQ(
-      std::nullopt,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", std::nullopt, "+05:30"));
-  EXPECT_EQ(
-      0,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", 0, "+00:00"));
-  EXPECT_EQ(
-      0,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", 0, "+05:30"));
-  EXPECT_EQ(
-      123,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", 4000000000123, "+00:00"));
-  EXPECT_EQ(
-      123,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", 4000000000123, "+05:30"));
-  EXPECT_EQ(
-      20,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", -980, "+00:00"));
-  EXPECT_EQ(
-      20,
-      evaluateWithTimestampWithTimezone<int32_t>(
-          "millisecond(c0)", -980, "+05:30"));
-}
+// TEST_F(DateTimeTest, millisecondTimestampWithTimezone) {
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", std::nullopt, std::nullopt));
+//   EXPECT_EQ(
+//       std::nullopt,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", std::nullopt, "+05:30"));
+//   EXPECT_EQ(
+//       0,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", 0, "+00:00"));
+//   EXPECT_EQ(
+//       0,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", 0, "+05:30"));
+//   EXPECT_EQ(
+//       123,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", 4000000000123, "+00:00"));
+//   EXPECT_EQ(
+//       123,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", 4000000000123, "+05:30"));
+//   EXPECT_EQ(
+//       20,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", -980, "+00:00"));
+//   EXPECT_EQ(
+//       20,
+//       evaluateWithTimestampWithTimezone<int32_t>(
+//           "millisecond(c0)", -980, "+05:30"));
+// }
 
 } // namespace
 } // namespace facebook::velox::functions::sparksql::test


### PR DESCRIPTION
- Remove TimestampWithTimeZone support in spark sql.
- Use PModFunction instead of PModIntFunction. PModFunction has bug and fixed in [velox PR 4516](https://github.com/facebookincubator/velox/pull/4516). 