### PR TITLE
Fix velox exec test

### DIFF
--- a/velox/exec/GroupId.cpp
+++ b/velox/exec/GroupId.cpp
@@ -88,13 +88,11 @@ RowVectorPtr GroupId::getOutput() {
   auto numGroupingKeys = mapping.size();
 
   // Fill in grouping keys.
-  auto gid = 0;
   for (auto i = 0; i < numGroupingKeys; ++i) {
     if (mapping[i] == kMissingGroupingKey) {
       // Add null column.
       outputColumns[i] = BaseVector::createNullConstant(
           outputType_->childAt(i), numInput, pool());
-      gid = 1 << (numGroupingKeys - i - 1) | gid;
     } else {
       outputColumns[i] = input_->childAt(mapping[i]);
     }
@@ -108,7 +106,7 @@ RowVectorPtr GroupId::getOutput() {
   // Add groupId column.
   outputColumns[outputType_->size() - 1] =
       std::make_shared<ConstantVector<int64_t>>(
-          pool(), numInput, false, BIGINT(), gid);
+          pool(), numInput, false, BIGINT(), groupingSetIndex_);
 
   ++groupingSetIndex_;
   if (groupingSetIndex_ == groupingKeyMappings_.size()) {

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -724,7 +724,9 @@ TEST_F(AggregationTest, largeValueRangeArray) {
 
   // The partial agg is expected to flush just once. The final agg gets one
   // batch.
-  EXPECT_EQ(1, stats.at(finalAggId).inputVectors);
+  // Change expectation of this case, because we make some change in
+  // https://github.com/oap-project/velox/pull/98.
+  EXPECT_EQ(2, stats.at(finalAggId).inputVectors);
 }
 
 TEST_F(AggregationTest, partialAggregationMemoryLimitIncrease) {
@@ -1230,7 +1232,9 @@ TEST_F(AggregationTest, groupingSets) {
 
   // Compute a subset of aggregates per grouping set by using masks based on
   // group_id column.
-  plan = PlanBuilder()
+  // comments this case, because we change group_id column in
+  // https://github.com/oap-project/velox/pull/65.
+  /*plan = PlanBuilder()
              .values({data})
              .groupId({{"k1"}, {"k2"}}, {"a", "b"})
              .project(
@@ -1252,7 +1256,7 @@ TEST_F(AggregationTest, groupingSets) {
       plan,
       "SELECT k1, null, count(1), sum(a), null FROM tmp GROUP BY k1 "
       "UNION ALL "
-      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");
+      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");*/
 
   // Cube.
   plan = PlanBuilder()

--- a/velox/exec/tests/AggregationTest.cpp
+++ b/velox/exec/tests/AggregationTest.cpp
@@ -1232,9 +1232,7 @@ TEST_F(AggregationTest, groupingSets) {
 
   // Compute a subset of aggregates per grouping set by using masks based on
   // group_id column.
-  // comments this case, because we change group_id column in
-  // https://github.com/oap-project/velox/pull/65.
-  /*plan = PlanBuilder()
+  plan = PlanBuilder()
              .values({data})
              .groupId({{"k1"}, {"k2"}}, {"a", "b"})
              .project(
@@ -1256,7 +1254,7 @@ TEST_F(AggregationTest, groupingSets) {
       plan,
       "SELECT k1, null, count(1), sum(a), null FROM tmp GROUP BY k1 "
       "UNION ALL "
-      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");*/
+      "SELECT null, k2, count(1), null, max(b) FROM tmp GROUP BY k2");
 
   // Cube.
   plan = PlanBuilder()


### PR DESCRIPTION
1. change expectation for AggregationTest.largeValueRangeArray.  caused by https://github.com/oap-project/velox/pull/98
2. revert gid calculation change caused by https://github.com/oap-project/velox/pull/65