### PR TITLE
Fallback array functions

### DIFF
--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -111,23 +111,13 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
     }
   }
   std::unordered_set<std::string> functions = {
-      "regexp_replace",
-      "split",
-      "split_part",
-      "factorial",
-      "concat_ws",
-      "rand",
-      "json_array_length",
-      "from_unixtime",
-      "to_unix_timestamp",
-      "unix_timestamp",
-      "repeat",
-      "translate",
-      "add_months",
-      "date_format",
-      "trunc",
-      "sequence",
-      "posexplode"};
+      "regexp_replace",    "split",         "split_part",
+      "factorial",         "concat_ws",     "rand",
+      "json_array_length", "from_unixtime", "to_unix_timestamp",
+      "unix_timestamp",    "repeat",        "translate",
+      "add_months",        "date_format",   "trunc",
+      "sequence",          "posexplode",    "arrays_overlap",
+      "array_min",         "array_max"};
   if (functions.find(name) != functions.end()) {
     VLOG(1) << "Function is not supported: " << name << ".";
     return false;


### PR DESCRIPTION
Fallback `arrays_overlap`, `array_min` and `array_max` functions due to incorrect result on NaN.