### PR TITLE
Parquet: Optimize parquet write perf

### DIFF
--- a/velox/core/QueryConfig.h
+++ b/velox/core/QueryConfig.h
@@ -115,6 +115,9 @@ class QueryConfig {
   /// output rows.
   static constexpr const char* kMaxOutputBatchRows = "max_output_batch_rows";
 
+  /// It is used when DataBuffer.reserve() method to reallocated buffer size.
+  static constexpr const char* kDataBufferGrowRatio = "data_buffer_grow_ratio";
+
   static constexpr const char* kHashAdaptivityEnabled =
       "driver.hash_adaptivity_enabled";
 
@@ -235,6 +238,10 @@ class QueryConfig {
 
   uint32_t maxOutputBatchRows() const {
     return get<uint32_t>(kMaxOutputBatchRows, 10'000);
+  }
+
+  uint32_t dataBufferGrowRatio() const {
+    return get<uint32_t>(kDataBufferGrowRatio, 1);
   }
 
   bool hashAdaptivityEnabled() const {

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -141,7 +141,11 @@ class DataBuffer {
     append(offset, src.data() + srcOffset, items);
   }
 
-  void append(uint64_t offset, const T* FOLLY_NONNULL src, uint64_t items, uint32_t growRatio = 1) {
+  void append(
+      uint64_t offset,
+      const T* FOLLY_NONNULL src,
+      uint64_t items,
+      uint32_t growRatio = 1) {
     reserve(offset + items, growRatio);
     unsafeAppend(offset, src, items);
   }

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -105,7 +105,7 @@ class DataBuffer {
     if (veloxRef_ != nullptr) {
       DWIO_RAISE("Can't reserve on a referenced buffer");
     }
-    const auto newSize = sizeInBytes(capacity);
+    const auto newSize = sizeInBytes(capacity) * 2;
     if (buf_ == nullptr) {
       buf_ = reinterpret_cast<T*>(pool_->allocate(newSize));
     } else {
@@ -113,7 +113,7 @@ class DataBuffer {
           pool_->reallocate(buf_, sizeInBytes(capacity_), newSize));
     }
     DWIO_ENSURE(buf_ != nullptr || newSize == 0);
-    capacity_ = capacity;
+    capacity_ = capacity * 2;
   }
 
   void extend(uint64_t size) {

--- a/velox/dwio/common/DataBuffer.h
+++ b/velox/dwio/common/DataBuffer.h
@@ -21,7 +21,6 @@
 #include <type_traits>
 #include "velox/buffer/Buffer.h"
 #include "velox/common/memory/Memory.h"
-#include "velox/core/QueryConfig.h"
 #include "velox/dwio/common/exception/Exception.h"
 
 namespace facebook {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -31,8 +31,8 @@ void Writer::write(const RowVectorPtr& data) {
   auto table = arrow::Table::Make(
       recordBatch->schema(), recordBatch->columns(), data->size());
   if (!arrowWriter_) {
-
-    stream_ = std::make_shared<DataBufferSink>(pool_, queryCtx_->queryConfig().dataBufferGrowRatio());
+    stream_ = std::make_shared<DataBufferSink>(
+        pool_, queryCtx_->queryConfig().dataBufferGrowRatio());
     auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
     PARQUET_ASSIGN_OR_THROW(
         arrowWriter_,

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -43,7 +43,7 @@ void Writer::write(const RowVectorPtr& data) {
             arrowProperties));
   }
 
-  PARQUET_THROW_NOT_OK(arrowWriter_->WriteRecordBatch(*recordBatch));
+  PARQUET_THROW_NOT_OK(arrowWriter_->WriteTable(*table, 10000));
 }
 
 void Writer::flush() {

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -31,7 +31,8 @@ void Writer::write(const RowVectorPtr& data) {
   auto table = arrow::Table::Make(
       recordBatch->schema(), recordBatch->columns(), data->size());
   if (!arrowWriter_) {
-    stream_ = std::make_shared<DataBufferSink>(pool_);
+
+    stream_ = std::make_shared<DataBufferSink>(pool_, queryCtx_->queryConfig().dataBufferGrowRatio());
     auto arrowProperties = ::parquet::ArrowWriterProperties::Builder().build();
     PARQUET_ASSIGN_OR_THROW(
         arrowWriter_,

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -20,6 +20,9 @@
 #include "velox/dwio/common/DataSink.h"
 
 #include "velox/vector/ComplexVector.h"
+#include "velox/core/QueryConfig.h"
+#include "velox/core/Context.h"
+#include "velox/core/QueryCtx.h"
 
 #include <parquet/arrow/writer.h> // @manual
 
@@ -28,18 +31,19 @@ namespace facebook::velox::parquet {
 // Utility for capturing Arrow output into a DataBuffer.
 class DataBufferSink : public arrow::io::OutputStream {
  public:
-  explicit DataBufferSink(memory::MemoryPool& pool) : buffer_(pool) {}
+  explicit DataBufferSink(memory::MemoryPool& pool, uint32_t growRatio = 1) : buffer_(pool), growRatio_(growRatio) {
+  }
 
   arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
     buffer_.append(
         buffer_.size(),
         reinterpret_cast<const char*>(data->data()),
-        data->size());
+        data->size(), growRatio_);
     return arrow::Status::OK();
   }
 
   arrow::Status Write(const void* data, int64_t nbytes) override {
-    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes);
+    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes, growRatio_);
     return arrow::Status::OK();
   }
 
@@ -64,7 +68,8 @@ class DataBufferSink : public arrow::io::OutputStream {
   }
 
  private:
-  dwio::common::DataBuffer<char> buffer_;
+  dwio::common::DataBuffer<char> buffer_; 
+  uint32_t growRatio_ = 1;
 };
 
 // Writes Velox vectors into  a DataSink using Arrow Parquet writer.
@@ -78,12 +83,15 @@ class Writer {
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool,
       int32_t rowsInRowGroup,
+      std::shared_ptr<velox::core::QueryCtx> queryCtx = std::make_shared<velox::core::QueryCtx>(
+        nullptr),
       std::shared_ptr<::parquet::WriterProperties> properties =
           ::parquet::WriterProperties::Builder().build())
       : rowsInRowGroup_(rowsInRowGroup),
         pool_(pool),
         finalSink_(std::move(sink)),
-        properties_(std::move(properties)) {}
+        properties_(std::move(properties)),
+        queryCtx_(std::move(queryCtx)) {}
 
   // Appends 'data' into the writer.
   void write(const RowVectorPtr& data);
@@ -113,6 +121,7 @@ class Writer {
   std::unique_ptr<::parquet::arrow::FileWriter> arrowWriter_;
 
   std::shared_ptr<::parquet::WriterProperties> properties_;
+  std::shared_ptr<velox::core::QueryCtx> queryCtx_;
 };
 
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -83,10 +83,10 @@ class Writer {
       std::unique_ptr<dwio::common::DataSink> sink,
       memory::MemoryPool& pool,
       int32_t rowsInRowGroup,
-      std::shared_ptr<velox::core::QueryCtx> queryCtx = std::make_shared<velox::core::QueryCtx>(
-        nullptr),
       std::shared_ptr<::parquet::WriterProperties> properties =
-          ::parquet::WriterProperties::Builder().build())
+          ::parquet::WriterProperties::Builder().build(),
+      std::shared_ptr<velox::core::QueryCtx> queryCtx = std::make_shared<velox::core::QueryCtx>(
+        nullptr))
       : rowsInRowGroup_(rowsInRowGroup),
         pool_(pool),
         finalSink_(std::move(sink)),

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -19,10 +19,10 @@
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/DataSink.h"
 
-#include "velox/vector/ComplexVector.h"
-#include "velox/core/QueryConfig.h"
 #include "velox/core/Context.h"
+#include "velox/core/QueryConfig.h"
 #include "velox/core/QueryCtx.h"
+#include "velox/vector/ComplexVector.h"
 
 #include <parquet/arrow/writer.h> // @manual
 
@@ -31,19 +31,24 @@ namespace facebook::velox::parquet {
 // Utility for capturing Arrow output into a DataBuffer.
 class DataBufferSink : public arrow::io::OutputStream {
  public:
-  explicit DataBufferSink(memory::MemoryPool& pool, uint32_t growRatio = 1) : buffer_(pool), growRatio_(growRatio) {
-  }
+  explicit DataBufferSink(memory::MemoryPool& pool, uint32_t growRatio = 1)
+      : buffer_(pool), growRatio_(growRatio) {}
 
   arrow::Status Write(const std::shared_ptr<arrow::Buffer>& data) override {
     buffer_.append(
         buffer_.size(),
         reinterpret_cast<const char*>(data->data()),
-        data->size(), growRatio_);
+        data->size(),
+        growRatio_);
     return arrow::Status::OK();
   }
 
   arrow::Status Write(const void* data, int64_t nbytes) override {
-    buffer_.append(buffer_.size(), reinterpret_cast<const char*>(data), nbytes, growRatio_);
+    buffer_.append(
+        buffer_.size(),
+        reinterpret_cast<const char*>(data),
+        nbytes,
+        growRatio_);
     return arrow::Status::OK();
   }
 
@@ -68,7 +73,7 @@ class DataBufferSink : public arrow::io::OutputStream {
   }
 
  private:
-  dwio::common::DataBuffer<char> buffer_; 
+  dwio::common::DataBuffer<char> buffer_;
   uint32_t growRatio_ = 1;
 };
 
@@ -85,8 +90,8 @@ class Writer {
       int32_t rowsInRowGroup,
       std::shared_ptr<::parquet::WriterProperties> properties =
           ::parquet::WriterProperties::Builder().build(),
-      std::shared_ptr<velox::core::QueryCtx> queryCtx = std::make_shared<velox::core::QueryCtx>(
-        nullptr))
+      std::shared_ptr<velox::core::QueryCtx> queryCtx =
+          std::make_shared<velox::core::QueryCtx>(nullptr))
       : rowsInRowGroup_(rowsInRowGroup),
         pool_(pool),
         finalSink_(std::move(sink)),


### PR DESCRIPTION
1. We found that the performance bottleneck is the constant reallocating of the memory pool. The reason is that `DataBuffer ` is directly reallocated in `reverse ` method , and `memcpy ` must be called every time, resulting in performance degradation. Here we adjust the size of each reallocate to 2 times. And the parquet write perf can be 1.31x in 500GB TPC-DS.
2. Revert the changed in [here](https://github.com/oap-project/velox/pull/207) and still use the WriteTable API to write parquet file.