### PR TITLE
Fix ambiguous call for devtoolset-9 on CentOS 7

### DIFF
--- a/velox/exec/tests/ValuesTest.cpp
+++ b/velox/exec/tests/ValuesTest.cpp
@@ -83,7 +83,7 @@ TEST_F(ValuesTest, valuesWithParallelism) {
 TEST_F(ValuesTest, valuesWithRepeat) {
   // Single vectors in with repeat, many vectors out.
   AssertQueryBuilder(PlanBuilder().values({input_}, false, 2).planNode())
-      .assertResults({input_, input_});
+      .assertResults(std::vector<RowVectorPtr>{input_, input_});
 
   AssertQueryBuilder(PlanBuilder().values({input_}, false, 7).planNode())
       .assertResults({input_, input_, input_, input_, input_, input_, input_});


### PR DESCRIPTION
# Reproduce

Build velox on CentOS 7:

```
$ ./ep/build-velox/src/build_velox.sh --build_benchmarks=ON
...
/opt/gluten/ep/build-velox/build/velox_ep/velox/exec/tests/ValuesTest.cpp: In member function 'virtual void facebook::velox::exec::test::ValuesTest_valuesWithRepeat_Test::TestBody()':
/opt/gluten/ep/build-velox/build/velox_ep/velox/exec/tests/ValuesTest.cpp:86:38: error: call of overloaded 'assertResults(<brace-enclosed initializer list>)' is ambiguous
   86 |       .assertResults({input_, input_});
      |                                      ^
In file included from /opt/gluten/ep/build-velox/build/velox_ep/velox/exec/tests/ValuesTest.cpp:17:
/opt/gluten/ep/build-velox/build/velox_ep/./velox/exec/tests/utils/AssertQueryBuilder.h:106:25: note: candidate: 'std::shared_ptr<facebook::velox::exec::Task> facebook::velox::exec::test::AssertQueryBuilder::assertResults(const string&, const std::optional<std::vector<unsigned int> >&)'
  106 |   std::shared_ptr<Task> assertResults(
      |                         ^~~~~~~~~~~~~
/opt/gluten/ep/build-velox/build/velox_ep/./velox/exec/tests/utils/AssertQueryBuilder.h:114:25: note: candidate: 'std::shared_ptr<facebook::velox::exec::Task> facebook::velox::exec::test::AssertQueryBuilder::assertResults(const std::vector<std::shared_ptr<facebook::velox::RowVector> >&)'
  114 |   std::shared_ptr<Task> assertResults(
      |                         ^~~~~~~~~~~~~
ninja: build stopped: subcommand failed.
```

Call of init list `{ptr, ptr}` is ambiguous between std:;string and std::vector. Here is a simple example:

``` c++
#include <vector>
#include <string>
#include <memory>

void f(const std::string&) {}

struct T {};
using Ptr = std::shared_ptr<T>;
void f(const std::vector<Ptr>&) {}

int main() {
    auto t = std::make_shared<T>();
    f({t, t});
}
```