### PR TITLE
[DWIO] refactor the reader of dwrf/orc

### DIFF
--- a/velox/dwio/dwrf/common/Common.cpp
+++ b/velox/dwio/dwrf/common/Common.cpp
@@ -36,6 +36,7 @@ std::string writerVersionToString(WriterVersion version) {
   return folly::to<std::string>("future - ", version);
 }
 
+/* unused
 std::string streamKindToString(StreamKind kind) {
   switch (static_cast<int32_t>(kind)) {
     case StreamKind_PRESENT:
@@ -63,6 +64,7 @@ std::string streamKindToString(StreamKind kind) {
   }
   return folly::to<std::string>("unknown - ", kind);
 }
+*/
 
 std::string columnEncodingKindToString(ColumnEncodingKind kind) {
   switch (static_cast<int32_t>(kind)) {
@@ -79,6 +81,11 @@ std::string columnEncodingKindToString(ColumnEncodingKind kind) {
 }
 
 DwrfStreamIdentifier EncodingKey::forKind(const proto::Stream_Kind kind) const {
+  return DwrfStreamIdentifier(node, sequence, 0, kind);
+}
+
+DwrfStreamIdentifier EncodingKey::forKind(
+    const proto::orc::Stream_Kind kind) const {
   return DwrfStreamIdentifier(node, sequence, 0, kind);
 }
 

--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -29,6 +29,11 @@
 
 namespace facebook::velox::dwrf {
 
+enum class DwrfFormat : uint8_t {
+  kDwrf = 0,
+  kOrc = 1,
+};
+
 // Writer version
 constexpr folly::StringPiece WRITER_NAME_KEY{"orc.writer.name"};
 constexpr folly::StringPiece WRITER_VERSION_KEY{"orc.writer.version"};
@@ -54,6 +59,7 @@ constexpr WriterVersion WriterVersion_CURRENT = WriterVersion::DWRF_7_0;
  */
 std::string writerVersionToString(WriterVersion kind);
 
+// Stream Kind of Dwrf
 enum StreamKind {
   StreamKind_PRESENT = 0,
   StreamKind_DATA = 1,
@@ -69,15 +75,39 @@ enum StreamKind {
   StreamKind_IN_MAP = 11
 };
 
+// Stream Kind of Orc
+enum StreamKindOrc {
+  StreamKindOrc_PRESENT = 0,
+  StreamKindOrc_DATA = 1,
+  StreamKindOrc_LENGTH = 2,
+  StreamKindOrc_DICTIONARY_DATA = 3,
+  StreamKindOrc_DICTIONARY_COUNT = 4,
+  StreamKindOrc_SECONDARY = 5,
+  StreamKindOrc_ROW_INDEX = 6,
+  StreamKindOrc_BLOOM_FILTER = 7,
+  StreamKindOrc_BLOOM_FILTER_UTF8 = 8,
+  StreamKindOrc_ENCRYPTED_INDEX = 9,
+  StreamKindOrc_ENCRYPTED_DATA = 10,
+  StreamKindOrc_STRIPE_STATISTICS = 100,
+  StreamKindOrc_FILE_STATISTICS = 101,
+
+  StreamKindOrc_INVALID = -1
+};
+
 inline bool isIndexStream(StreamKind kind) {
   return kind == StreamKind::StreamKind_ROW_INDEX ||
       kind == StreamKind::StreamKind_BLOOM_FILTER_UTF8;
 }
 
+inline bool isIndexStream(StreamKindOrc kind) {
+  return kind == StreamKindOrc::StreamKindOrc_ROW_INDEX ||
+      kind == StreamKindOrc::StreamKindOrc_ENCRYPTED_INDEX;
+}
+
 /**
  * Get the string representation of the StreamKind.
  */
-std::string streamKindToString(StreamKind kind);
+// std::string streamKindToString(StreamKind kind);
 
 class StreamInformation {
  public:
@@ -90,6 +120,12 @@ class StreamInformation {
   virtual uint64_t getLength() const = 0;
   virtual bool getUseVInts() const = 0;
   virtual bool valid() const = 0;
+
+  // providing a default implementation otherwise leading to too much compiling
+  // errors
+  virtual StreamKindOrc getKindOrc() const {
+    return StreamKindOrc_INVALID;
+  }
 };
 
 enum ColumnEncodingKind {
@@ -100,6 +136,7 @@ enum ColumnEncodingKind {
 };
 
 class DwrfStreamIdentifier;
+
 class EncodingKey {
  public:
   static const EncodingKey& getInvalid() {
@@ -107,14 +144,13 @@ class EncodingKey {
     return INVALID;
   }
 
- public:
+  uint32_t node;
+  uint32_t sequence;
+
   EncodingKey()
       : EncodingKey(dwio::common::MAX_UINT32, dwio::common::MAX_UINT32) {}
 
-  /* implicit */ EncodingKey(uint32_t n, uint32_t s = 0)
-      : node{n}, sequence{s} {}
-  uint32_t node;
-  uint32_t sequence;
+  EncodingKey(uint32_t n, uint32_t s = 0) : node{n}, sequence{s} {}
 
   bool operator==(const EncodingKey& other) const {
     return node == other.node && sequence == other.sequence;
@@ -133,6 +169,8 @@ class EncodingKey {
   }
 
   DwrfStreamIdentifier forKind(const proto::Stream_Kind kind) const;
+
+  DwrfStreamIdentifier forKind(const proto::orc::Stream_Kind kind) const;
 };
 
 struct EncodingKeyHash {
@@ -150,13 +188,22 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
 
  public:
   DwrfStreamIdentifier()
-      : column_(dwio::common::MAX_UINT32), kind_(StreamKind_DATA) {}
+      : column_(dwio::common::MAX_UINT32),
+        format_(DwrfFormat::kDwrf),
+        kind_(StreamKind_DATA) {}
 
-  /* implicit */ DwrfStreamIdentifier(const proto::Stream& stream)
+  DwrfStreamIdentifier(const proto::Stream& stream)
       : DwrfStreamIdentifier(
             stream.node(),
             stream.has_sequence() ? stream.sequence() : 0,
             stream.has_column() ? stream.column() : dwio::common::MAX_UINT32,
+            stream.kind()) {}
+
+  DwrfStreamIdentifier(const proto::orc::Stream& stream)
+      : DwrfStreamIdentifier(
+            stream.column(),
+            0,
+            dwio::common::MAX_UINT32,
             stream.kind()) {}
 
   DwrfStreamIdentifier(
@@ -167,7 +214,20 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
       : StreamIdentifier(
             velox::cache::TrackingId((node << kNodeShift) | kind).id()),
         column_{column},
+        format_(DwrfFormat::kDwrf),
         kind_(kind),
+        encodingKey_{node, sequence} {}
+
+  DwrfStreamIdentifier(
+      uint32_t node,
+      uint32_t sequence,
+      uint32_t column,
+      StreamKindOrc kind)
+      : StreamIdentifier(
+            velox::cache::TrackingId((node << kNodeShift) | kind).id()),
+        column_{column},
+        format_(DwrfFormat::kOrc),
+        kindOrc_(kind),
         encodingKey_{node, sequence} {}
 
   DwrfStreamIdentifier(
@@ -181,6 +241,17 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
             column,
             static_cast<StreamKind>(pkind)) {}
 
+  DwrfStreamIdentifier(
+      uint32_t node,
+      uint32_t sequence,
+      uint32_t column,
+      proto::orc::Stream_Kind pkind)
+      : DwrfStreamIdentifier(
+            node,
+            sequence,
+            column,
+            static_cast<StreamKindOrc>(pkind)) {}
+
   ~DwrfStreamIdentifier() = default;
 
   bool operator==(const DwrfStreamIdentifier& other) const {
@@ -189,7 +260,7 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
     return encodingKey_ == other.encodingKey_ && kind_ == other.kind_;
   }
 
-  std::size_t hash() const {
+  std::size_t hash() const override {
     return encodingKey_.hash() ^ std::hash<uint32_t>()(kind_);
   }
 
@@ -197,21 +268,30 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
     return column_;
   }
 
+  DwrfFormat format() const {
+    return format_;
+  }
+
   const StreamKind& kind() const {
     return kind_;
+  }
+
+  const StreamKindOrc& kindOrc() const {
+    return kindOrc_;
   }
 
   const EncodingKey& encodingKey() const {
     return encodingKey_;
   }
 
-  std::string toString() const {
+  std::string toString() const override {
     return fmt::format(
-        "[id={}, node={}, sequence={}, column={}, kind={}]",
+        "[id={}, node={}, sequence={}, column={}, format={}, kind={}]",
         id_,
         encodingKey_.node,
         encodingKey_.sequence,
         column_,
+        (uint32_t)format_,
         static_cast<uint32_t>(kind_));
   }
 
@@ -219,7 +299,13 @@ class DwrfStreamIdentifier : public dwio::common::StreamIdentifier {
   static constexpr int32_t kNodeShift = 5;
 
   uint32_t column_;
-  StreamKind kind_;
+
+  DwrfFormat format_;
+  union {
+    StreamKind kind_; // format_ == kDwrf
+    StreamKindOrc kindOrc_; // format_ == kOrc
+  };
+
   EncodingKey encodingKey_;
 };
 

--- a/velox/dwio/dwrf/common/Common.h
+++ b/velox/dwio/dwrf/common/Common.h
@@ -59,7 +59,7 @@ constexpr WriterVersion WriterVersion_CURRENT = WriterVersion::DWRF_7_0;
  */
 std::string writerVersionToString(WriterVersion kind);
 
-// Stream Kind of Dwrf
+// Stream kind of dwrf.
 enum StreamKind {
   StreamKind_PRESENT = 0,
   StreamKind_DATA = 1,
@@ -75,7 +75,7 @@ enum StreamKind {
   StreamKind_IN_MAP = 11
 };
 
-// Stream Kind of Orc
+// Stream kind of orc.
 enum StreamKindOrc {
   StreamKindOrc_PRESENT = 0,
   StreamKindOrc_DATA = 1,
@@ -101,7 +101,8 @@ inline bool isIndexStream(StreamKind kind) {
 
 inline bool isIndexStream(StreamKindOrc kind) {
   return kind == StreamKindOrc::StreamKindOrc_ROW_INDEX ||
-      kind == StreamKindOrc::StreamKindOrc_ENCRYPTED_INDEX;
+      kind == StreamKindOrc::StreamKindOrc_BLOOM_FILTER ||
+      kind == StreamKindOrc::StreamKindOrc_BLOOM_FILTER_UTF8;
 }
 
 /**

--- a/velox/dwio/dwrf/common/FileMetadata.h
+++ b/velox/dwio/dwrf/common/FileMetadata.h
@@ -25,11 +25,6 @@
 
 namespace facebook::velox::dwrf {
 
-enum class DwrfFormat : uint8_t {
-  kDwrf = 0,
-  kOrc = 1,
-};
-
 class ProtoWrapperBase {
  protected:
   ProtoWrapperBase(DwrfFormat format, const void* impl)

--- a/velox/dwio/dwrf/reader/ColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/ColumnReader.cpp
@@ -1851,7 +1851,7 @@ ListColumnReader::ListColumnReader(
     VELOX_CHECK(stripe.format() == DwrfFormat::kOrc);
     // Count the number of selected sub-columns.
     vers = convertRleVersion(stripe.getEncodingOrc(encodingKey).kind());
-    auto lenId = encodingKey.forKind(proto::orc::Stream_Kind_LENGTH);
+    lenId = encodingKey.forKind(proto::orc::Stream_Kind_LENGTH);
   }
 
   length = createRleDecoder</*isSigned*/ false>(

--- a/velox/dwio/dwrf/reader/DwrfData.h
+++ b/velox/dwio/dwrf/reader/DwrfData.h
@@ -95,6 +95,10 @@ class DwrfData : public dwio::common::FormatData {
         entry.positions().begin(), entry.positions().end());
   }
 
+  void init(StripeStreams& stripe);
+  void initDwrf(StripeStreams& stripe);
+  void initOrc(StripeStreams& stripe);
+
   memory::MemoryPool& memoryPool_;
   const std::shared_ptr<const dwio::common::TypeWithId> nodeType_;
   FlatMapContext flatMapContext_;
@@ -148,6 +152,19 @@ inline RleVersion convertRleVersion(proto::ColumnEncoding_Kind kind) {
       return RleVersion_1;
     case proto::ColumnEncoding_Kind_DIRECT_V2:
     case proto::ColumnEncoding_Kind_DICTIONARY_V2:
+      return RleVersion_2;
+    default:
+      DWIO_RAISE("Unknown encoding in convertRleVersion");
+  }
+}
+
+inline RleVersion convertRleVersion(proto::orc::ColumnEncoding_Kind kind) {
+  switch (static_cast<int64_t>(kind)) {
+    case proto::orc::ColumnEncoding_Kind_DIRECT:
+    case proto::orc::ColumnEncoding_Kind_DICTIONARY:
+      return RleVersion_1;
+    case proto::orc::ColumnEncoding_Kind_DIRECT_V2:
+    case proto::orc::ColumnEncoding_Kind_DICTIONARY_V2:
       return RleVersion_2;
     default:
       DWIO_RAISE("Unknown encoding in convertRleVersion");

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -202,6 +202,7 @@ ReaderBase::ReaderBase(
           postScript_->cacheMode(), *footer_, std::move(cacheBuffer));
     }
   }
+
   if (!cache_ && input_->shouldPrefetchStripes()) {
     auto numStripes = getFooter().stripesSize();
     for (auto i = 0; i < numStripes; i++) {
@@ -214,6 +215,7 @@ ReaderBase::ReaderBase(
       input_->load(LogType::FOOTER);
     }
   }
+
   // initialize file decrypter
   handler_ = DecryptionHandler::create(*footer_, decryptorFactory_.get());
 }

--- a/velox/dwio/dwrf/reader/ReaderBase.h
+++ b/velox/dwio/dwrf/reader/ReaderBase.h
@@ -100,6 +100,30 @@ class ReaderBase {
     }
   }
 
+  ReaderBase(
+      memory::MemoryPool& pool,
+      std::unique_ptr<dwio::common::BufferedInput> input,
+      std::unique_ptr<PostScript> ps,
+      const proto::orc::Footer* footer,
+      std::unique_ptr<StripeMetadataCache> cache,
+      std::unique_ptr<encryption::DecryptionHandler> handler = nullptr)
+      : pool_{pool},
+        postScript_{std::move(ps)},
+        footer_{std::make_unique<FooterWrapper>(footer)},
+        cache_{std::move(cache)},
+        handler_{std::move(handler)},
+        input_{std::move(input)},
+        schema_{
+            std::dynamic_pointer_cast<const RowType>(convertType(*footer_))},
+        fileLength_{0},
+        psLength_{0} {
+    DWIO_ENSURE(footer_->getOrcPtr()->GetArena());
+    DWIO_ENSURE_NOT_NULL(schema_, "invalid schema");
+    if (!handler_) {
+      handler_ = encryption::DecryptionHandler::create(*footer_);
+    }
+  }
+
   // for testing
   explicit ReaderBase(memory::MemoryPool& pool) : pool_{pool} {}
 

--- a/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveFloatingPointColumnReader.h
@@ -73,7 +73,10 @@ SelectiveFloatingPointColumnReader<TData, TRequested>::
       decoder_(params.stripeStreams().getStream(
           EncodingKey{root::nodeType_->id, params.flatMapContext().sequence}
               .forKind(proto::Stream_Kind_DATA),
-          true)) {}
+          true)) {
+  VELOX_CHECK(
+      (int)proto::Stream_Kind_DATA == (int)proto::orc::Stream_Kind_DATA);
+}
 
 template <typename TData, typename TRequested>
 uint64_t SelectiveFloatingPointColumnReader<TData, TRequested>::skip(

--- a/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveIntegerDictionaryColumnReader.cpp
@@ -34,6 +34,7 @@ SelectiveIntegerDictionaryColumnReader::SelectiveIntegerDictionaryColumnReader(
           dataType->type) {
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
+  VELOX_CHECK(stripe.format() == DwrfFormat::kDwrf);
   auto encoding = stripe.getEncoding(encodingKey);
   scanState_.dictionary.numValues = encoding.dictionarysize();
   rleVersion_ = convertRleVersion(encoding.kind());

--- a/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
@@ -26,6 +26,49 @@ namespace facebook::velox::dwrf {
 
 class SelectiveLongDecimalColumnReader
     : public dwio::common::SelectiveColumnReader {
+  void init(DwrfParams& params) {
+    format_ = params.stripeStreams().format();
+    if (format_ == DwrfFormat::kDwrf) {
+      initDwrf(params);
+    } else {
+      VELOX_CHECK(format_ == DwrfFormat::kOrc);
+      initOrc(params);
+    }
+  }
+
+  void initDwrf(DwrfParams& params) {
+    VELOX_FAIL("dwrf unsupport decimal");
+  }
+
+  void initOrc(DwrfParams& params) {
+    auto& stripe = params.stripeStreams();
+
+    EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
+    auto values = encodingKey.forKind(proto::orc::Stream_Kind_DATA);
+    auto scales = encodingKey.forKind(proto::orc::Stream_Kind_SECONDARY);
+
+    bool valuesVInts = stripe.getUseVInts(values);
+    bool scalesVInts = stripe.getUseVInts(scales);
+
+    auto encoding = stripe.getEncodingOrc(encodingKey);
+    auto encodingKind = encoding.kind();
+    VELOX_CHECK(
+        encodingKind == proto::orc::ColumnEncoding_Kind_DIRECT ||
+        encodingKind == proto::orc::ColumnEncoding_Kind_DIRECT_V2);
+
+    version_ = convertRleVersion(encodingKind);
+
+    valueDecoder_ = createDirectDecoder<true>(
+        stripe.getStream(values, true), valuesVInts, sizeof(int128_t));
+
+    scaleDecoder_ = createRleDecoder<true>(
+        stripe.getStream(scales, true),
+        version_,
+        params.pool(),
+        scalesVInts,
+        facebook::velox::dwio::common::LONG_BYTE_SIZE);
+  }
+
  public:
   using ValueType = int128_t;
 
@@ -37,42 +80,7 @@ class SelectiveLongDecimalColumnReader
       : SelectiveColumnReader(nodeType, params, scanSpec, nodeType->type) {
     precision_ = dataType->asLongDecimal().precision();
     scale_ = dataType->asLongDecimal().scale();
-
-    auto& stripe = params.stripeStreams();
-
-    EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
-    auto values = encodingKey.forKind(proto::Stream_Kind_DATA);
-    auto scales = encodingKey.forKind(
-        proto::Stream_Kind_NANO_DATA); // equal to
-                                       // orc::proto::Stream_Kind_SECONDARY
-
-    bool valuesVInts = stripe.getUseVInts(values);
-    bool scalesVInts = stripe.getUseVInts(scales);
-
-    format_ = stripe.format();
-    if (format_ == velox::dwrf::DwrfFormat::kDwrf) {
-      VELOX_FAIL("dwrf unsupport decimal");
-    } else if (format_ == velox::dwrf::DwrfFormat::kOrc) {
-      auto encoding = stripe.getEncoding(encodingKey);
-      auto encodingKind = encoding.kind();
-      VELOX_CHECK(
-          encodingKind == proto::ColumnEncoding_Kind_DIRECT ||
-          encodingKind == proto::ColumnEncoding_Kind_DIRECT_V2);
-
-      version_ = convertRleVersion(encodingKind);
-
-      valueDecoder_ = createDirectDecoder<true>(
-          stripe.getStream(values, true), valuesVInts, sizeof(int128_t));
-
-      scaleDecoder_ = createRleDecoder<true>(
-          stripe.getStream(scales, true),
-          version_,
-          params.pool(),
-          scalesVInts,
-          facebook::velox::dwio::common::LONG_BYTE_SIZE);
-    } else {
-      VELOX_FAIL("invalid stripe format");
-    }
+    init(params);
   }
 
   bool hasBulkPath() const override {

--- a/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDictionaryColumnReader.h
@@ -71,6 +71,10 @@ class SelectiveStringDictionaryColumnReader
   void loadStrideDictionary();
   void makeDictionaryBaseVector();
 
+  void init(DwrfParams& params);
+  void initDwrf(DwrfParams& params);
+  void initOrc(DwrfParams& params);
+
   template <typename TVisitor>
   void readWithVisitor(RowSet rows, TVisitor visitor);
 

--- a/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStringDirectColumnReader.h
@@ -23,6 +23,20 @@ namespace facebook::velox::dwrf {
 
 class SelectiveStringDirectColumnReader
     : public dwio::common::SelectiveColumnReader {
+  void init(DwrfParams& params) {
+    auto format = params.stripeStreams().format();
+    if (format == DwrfFormat::kDwrf) {
+      initDwrf(params);
+    } else {
+      VELOX_CHECK(format == DwrfFormat::kOrc);
+      initOrc(params);
+    }
+  }
+
+  void initDwrf(DwrfParams& params);
+
+  void initOrc(DwrfParams& params);
+
  public:
   using ValueType = StringView;
   SelectiveStringDirectColumnReader(

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -32,13 +32,10 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
           dataType,
           params,
           scanSpec) {
+  init(params);
+
   EncodingKey encodingKey{nodeType_->id, params.flatMapContext().sequence};
   auto& stripe = params.stripeStreams();
-  auto encoding = static_cast<int64_t>(stripe.getEncoding(encodingKey).kind());
-  DWIO_ENSURE_EQ(
-      encoding,
-      proto::ColumnEncoding_Kind_DIRECT,
-      "Unknown encoding for StructColumnReader");
 
   const auto& cs = stripe.getColumnSelector();
   // A reader tree may be constructed while the ScanSpec is being used

--- a/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveTimestampColumnReader.h
@@ -23,6 +23,20 @@
 namespace facebook::velox::dwrf {
 class SelectiveTimestampColumnReader
     : public dwio::common::SelectiveColumnReader {
+  void init(DwrfParams& params) {
+    auto format = params.stripeStreams().format();
+    if (format == DwrfFormat::kDwrf) {
+      initDwrf(params);
+    } else {
+      VELOX_CHECK(format == DwrfFormat::kOrc);
+      initOrc(params);
+    }
+  }
+
+  void initDwrf(DwrfParams& params);
+
+  void initOrc(DwrfParams& params);
+
  public:
   // The readers produce int64_t, the vector is Timestamps.
   using ValueType = int64_t;


### PR DESCRIPTION
Why I do this? please refer to [discussion](https://github.com/facebookincubator/velox/discussions/4933)

We use the `proto::Stream_Kind_xxx` both for `dwrf` and `orc`, and this usage is dangerous, so I refactor this part by the following modifications:
1. add another constructor with a param `proto::orc::Stream` for `DwrfStreamIdentifier`
2. add another member method of `forKind(const proto::orc::Stream_Kind kind)` for `EncodingKey`
3. using union to represent of `proto::orc::StripeFooter* footerOrc_` for orc
4. add `StripeStreams::getEncodingOrc()` for `orc`, the response to  `StripeStreams::getEncoding()` for `dwrf`
5. refactor loadStreams to avoid the mess
6. add `init` for sub-classes of `SelectiveColumnReader`,  check the format in `init()`, call `initDwrf` for dwrf and call `initOrc` for orc 