### PR TITLE
Align the implementation for ascii function with spark sql 

### DIFF
--- a/velox/functions/sparksql/String.h
+++ b/velox/functions/sparksql/String.h
@@ -27,7 +27,13 @@ struct AsciiFunction {
   VELOX_DEFINE_FUNCTION_TYPES(T);
 
   FOLLY_ALWAYS_INLINE bool call(int32_t& result, const arg_type<Varchar>& s) {
-    result = s.empty() ? 0 : s.data()[0];
+    if (s.empty()) {
+      result = 0;
+      return true;
+    }
+    int charLen = utf8proc_char_length(s.data());
+    int size;
+    result = utf8proc_codepoint(s.data(), s.data() + charLen, size);
     return true;
   }
 };

--- a/velox/functions/sparksql/tests/StringTest.cpp
+++ b/velox/functions/sparksql/tests/StringTest.cpp
@@ -145,8 +145,11 @@ class StringTest : public SparkFunctionBaseTest {
 TEST_F(StringTest, Ascii) {
   EXPECT_EQ(ascii(std::string("\0", 1)), 0);
   EXPECT_EQ(ascii(" "), 32);
-  EXPECT_EQ(ascii("😋"), -16);
+  EXPECT_EQ(ascii("😋"), 128523);
   EXPECT_EQ(ascii(""), 0);
+  EXPECT_EQ(ascii("¥"), 165);
+  EXPECT_EQ(ascii("®"), 174);
+  EXPECT_EQ(ascii("©"), 169);
   EXPECT_EQ(ascii(std::nullopt), std::nullopt);
 }
 


### PR DESCRIPTION
Since spark's latest releases, like spark 3.2.3/3.3.1 or higher versions, ascii function will return the code point for initial character of given input string. Character with two or more bytes needs to be considered.