### PR TITLE
Fix casting from decimal to bool

### DIFF
--- a/velox/expression/CastExpr.cpp
+++ b/velox/expression/CastExpr.cpp
@@ -78,11 +78,19 @@ void applyCastKernel(
     if constexpr (
         CppToType<From>::typeKind == TypeKind::SHORT_DECIMAL ||
         CppToType<From>::typeKind == TypeKind::LONG_DECIMAL) {
-      auto output = util::
-          Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
-              cast(input->valueAt(row), nullOutput, input->type());
-      if (!nullOutput) {
-        result->set(row, output);
+      if constexpr (CppToType<To>::typeKind == TypeKind::BOOLEAN) {
+        auto output = util::Converter<CppToType<To>::typeKind>::cast(
+            input->valueAt(row), nullOutput);
+        if (!nullOutput) {
+          result->set(row, output);
+        }
+      } else {
+        auto output = util::
+            Converter<CppToType<To>::typeKind, void, Truncate, AllowDecimal>::
+                cast(input->valueAt(row), nullOutput, input->type());
+        if (!nullOutput) {
+          result->set(row, output);
+        }
       }
     } else {
       auto output = util::

--- a/velox/type/Conversions.h
+++ b/velox/type/Conversions.h
@@ -90,11 +90,17 @@ struct Converter<TypeKind::BOOLEAN> {
   }
 
   static T cast(const UnscaledLongDecimal& d, bool& nullOutput) {
-    return folly::to<T>(d.unscaledValue());
+    if (d.unscaledValue() == 0) {
+      return false;
+    }
+    return true;
   }
 
   static T cast(const UnscaledShortDecimal& d, bool& nullOutput) {
-    return folly::to<T>(d.unscaledValue());
+    if (d.unscaledValue() == 0) {
+      return false;
+    }
+    return true;
   }
 };
 


### PR DESCRIPTION
When casting from decimal to bool, Spark only check if a decimal is zero. If yes, the result is true, otherwise false.