### PR TITLE
[ORC] add max/min support for orc decimal reader

### DIFF
--- a/velox/dwio/common/SelectiveColumnReader.h
+++ b/velox/dwio/common/SelectiveColumnReader.h
@@ -631,6 +631,10 @@ namespace facebook::velox::dwio::common {
 // Template parameter to indicate no hook in fast scan path. This is
 // referenced in decoders, thus needs to be declared in a header.
 struct NoHook : public ValueHook {
+  std::string toString() const override {
+    return "NoHook";
+  }
+
   void addValue(vector_size_t /*row*/, const void* FOLLY_NULLABLE /*value*/)
       override {}
 };

--- a/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
@@ -115,7 +115,29 @@ class SelectiveLongDecimalColumnReader
  private:
   template <bool dense>
   void processValueHook(RowSet rows, ValueHook* hook) {
-    VELOX_FAIL("TODO: orc long decimal process ValueHook");
+    // std::cout << "long decimal hook: %s" << hook->toString() << std::endl;
+
+    switch (hook->kind()) {
+      case aggregate::AggregationHook::kLongDecimalMax:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToHook<
+                aggregate::MinMaxHook<UnscaledLongDecimal, false>>(hook));
+        break;
+      case aggregate::AggregationHook::kLongDecimalMin:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToHook<
+                aggregate::MinMaxHook<UnscaledLongDecimal, true>>(hook));
+        break;
+      default:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(hook));
+    }
   }
 
   template <bool dense, typename ExtractValues>

--- a/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveLongDecimalColumnReader.h
@@ -115,8 +115,6 @@ class SelectiveLongDecimalColumnReader
  private:
   template <bool dense>
   void processValueHook(RowSet rows, ValueHook* hook) {
-    // std::cout << "long decimal hook: %s" << hook->toString() << std::endl;
-
     switch (hook->kind()) {
       case aggregate::AggregationHook::kLongDecimalMax:
         readHelper<dense, velox::common::AlwaysTrue>(

--- a/velox/dwio/dwrf/reader/SelectiveShortDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveShortDecimalColumnReader.h
@@ -121,7 +121,29 @@ class SelectiveShortDecimalColumnReader
  private:
   template <bool dense>
   void processValueHook(RowSet rows, ValueHook* hook) {
-    VELOX_FAIL("TODO: orc short decimal process ValueHook");
+    // std::cout << "short decimal hook: %s" << hook->toString() << std::endl;
+
+    switch (hook->kind()) {
+      case aggregate::AggregationHook::kShortDecimalMax:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToHook<
+                aggregate::MinMaxHook<UnscaledShortDecimal, false>>(hook));
+        break;
+      case aggregate::AggregationHook::kShortDecimalMin:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToHook<
+                aggregate::MinMaxHook<UnscaledShortDecimal, true>>(hook));
+        break;
+      default:
+        readHelper<dense, velox::common::AlwaysTrue>(
+            &dwio::common::alwaysTrue(),
+            rows,
+            dwio::common::ExtractToGenericHook(hook));
+    }
   }
 
   template <bool dense, typename ExtractValues>

--- a/velox/dwio/dwrf/reader/SelectiveShortDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveShortDecimalColumnReader.h
@@ -121,8 +121,6 @@ class SelectiveShortDecimalColumnReader
  private:
   template <bool dense>
   void processValueHook(RowSet rows, ValueHook* hook) {
-    // std::cout << "short decimal hook: %s" << hook->toString() << std::endl;
-
     switch (hook->kind()) {
       case aggregate::AggregationHook::kShortDecimalMax:
         readHelper<dense, velox::common::AlwaysTrue>(

--- a/velox/vector/LazyVector.h
+++ b/velox/vector/LazyVector.h
@@ -45,6 +45,10 @@ class ValueHook {
 
   virtual ~ValueHook() = default;
 
+  virtual std::string toString() const {
+    return "ValueHook";
+  }
+
   virtual bool acceptsNulls() const {
     return false;
   }


### PR DESCRIPTION
fix the crash caused by `decimal::max/min` In Meituan's orc format environment