### PR TITLE
Ut fix for spark3.3

### DIFF
--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -326,8 +326,8 @@ TypePtr ReaderBase::convertType(
       case thrift::ConvertedType::INT_64:
         VELOX_CHECK_EQ(
             schemaElement.type,
-            thrift::Type::INT32,
-            "INT64 converted type can only be set for value of thrift::Type::INT32");
+            thrift::Type::INT64,
+            "INT64 converted type can only be set for value of thrift::Type::INT64");
         return BIGINT();
 
       case thrift::ConvertedType::UINT_8:

--- a/velox/substrait/SubstraitToVeloxPlanValidator.cpp
+++ b/velox/substrait/SubstraitToVeloxPlanValidator.cpp
@@ -139,6 +139,12 @@ bool SubstraitToVeloxPlanValidator::validateScalarFunction(
   if (name == "extract") {
     return validateExtractExpr(params);
   }
+  if (name == "regexp_extract_all" &&
+      !scalarFunction.arguments()[1].value().has_literal()) {
+    VLOG(1)
+        << "native validation failed due to: pattern is not literal for regex_extract_all.";
+    return false;
+  }
   if (name == "char_length") {
     VELOX_CHECK(types.size() == 1);
     if (types[0] == "vbin") {


### PR DESCRIPTION
The check for int64 is not correct and introduce error when read long with annotation.
add validation check for "regex_extract_all"