### PR TITLE
fix metrics for sort and window operation

### DIFF
--- a/velox/exec/Driver.cpp
+++ b/velox/exec/Driver.cpp
@@ -423,9 +423,9 @@ StopReason Driver::runInternal(
               }
               RuntimeStatWriterScopeGuard statsWriterGuard(op);
               if (op->isFinished()) {
-                auto timer =
-                    createDeltaCpuWallTimer([op](const CpuWallTiming& timing) {
-                      op->stats().wlock()->finishTiming.add(timing);
+                auto timer = createDeltaCpuWallTimer(
+                    [nextOp](const CpuWallTiming& timing) {
+                      nextOp->stats().wlock()->finishTiming.add(timing);
                     });
                 RuntimeStatWriterScopeGuard statsWriterGuard(nextOp);
                 nextOp->noMoreInput();


### PR DESCRIPTION
Velox calculated wrong total time metrics for sort and window operations. `nextOp->noMoreInput()` 's duration is recorded in paraent op's stats, but for sort and window operations, almost all works are executed in `noMoreInput `function. So we observed wrong total time metrics for them.
Before:
![image](https://github.com/oap-project/velox/assets/10524738/b733a272-44a3-499f-a92c-155bebb2df9b)

After:
![image](https://github.com/oap-project/velox/assets/10524738/1a2c8c94-e284-45a4-9398-6f86776e4592)
