### PR TITLE
Change the error on unreleased memory into warning

### DIFF
--- a/velox/common/memory/MemoryAllocator.cpp
+++ b/velox/common/memory/MemoryAllocator.cpp
@@ -103,7 +103,10 @@ class MallocAllocator : public MemoryAllocator {
   MallocAllocator();
 
   ~MallocAllocator() {
-    VELOX_CHECK((numAllocated_ == 0) && (numMapped_ == 0), "{}", toString());
+    if (numAllocated_ != 0 || numMapped_ != 0) {
+      VELOX_MEM_LOG(WARNING)
+          << "Unreleased allocation detected: " << toString();
+    }
   }
 
   Kind kind() const override {


### PR DESCRIPTION
Error on unreleased memory occurs in Gluten CI and interrupts the tests frequently. This PR changes this error into warning first.