### PR TITLE
cherrypick add simdjson build framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -418,6 +418,7 @@ jobs:
     environment:
       VELOX_DEPENDENCY_SOURCE: SYSTEM
       ICU_SOURCE: BUNDLED
+      simdjson_SOURCE: BUNDLED
     steps:
       - pre-steps
       - run:

--- a/CMake/resolve_dependency_modules/simdjson.cmake
+++ b/CMake/resolve_dependency_modules/simdjson.cmake
@@ -1,0 +1,32 @@
+# Copyright (c) Facebook, Inc. and its affiliates.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+include_guard(GLOBAL)
+
+set(VELOX_SIMDJSON_VERSION 3.1.5)
+set(VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM
+    5b916be17343324426fc467a4041a30151e481700d60790acfd89716ecc37076)
+set(VELOX_SIMDJSON_SOURCE_URL
+    "https://github.com/simdjson/simdjson/archive/refs/tags/v${VELOX_SIMDJSON_VERSION}.tar.gz"
+)
+
+resolve_dependency_url(SIMDJSON)
+
+message(STATUS "Building simdjson from source")
+
+FetchContent_Declare(
+  simdjson
+  URL ${VELOX_SIMDJSON_SOURCE_URL}
+  URL_HASH ${VELOX_SIMDJSON_BUILD_SHA256_CHECKSUM})
+
+FetchContent_MakeAvailable(simdjson)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -381,6 +381,9 @@ if(${VELOX_BUILD_PYTHON_PACKAGE})
   add_subdirectory(pyvelox)
 endif()
 
+set_source(simdjson)
+resolve_dependency(simdjson 3.1.5)
+
 # Locate or build folly.
 set_source(folly)
 resolve_dependency(folly)

--- a/velox/functions/prestosql/SIMDJsonFunctions.h
+++ b/velox/functions/prestosql/SIMDJsonFunctions.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include "simdjson.h"
+#include "velox/functions/Macros.h"
+#include "velox/functions/UDFOutputString.h"
+#include "velox/functions/prestosql/json/JsonPathTokenizer.h"
+#include "velox/functions/prestosql/types/JsonType.h"
+
+namespace facebook::velox::functions {
+
+struct ParserContext {
+ public:
+  explicit ParserContext() noexcept;
+  explicit ParserContext(const char* data, size_t length) noexcept
+      : padded_json(data, length) {}
+  void parseElement() {
+    jsonEle = domParser.parse(padded_json);
+  }
+  void parseDocument() {
+    jsonDoc = ondemandParser.iterate(padded_json);
+  }
+  simdjson::dom::element jsonEle;
+  simdjson::ondemand::document jsonDoc;
+
+ private:
+  simdjson::padded_string padded_json;
+  simdjson::dom::parser domParser;
+  simdjson::ondemand::parser ondemandParser;
+};
+
+template <typename T>
+struct SIMDIsJsonScalarFunction {
+  VELOX_DEFINE_FUNCTION_TYPES(T);
+
+  FOLLY_ALWAYS_INLINE void call(bool& result, const arg_type<Json>& json) {
+    ParserContext ctx(json.data(), json.size());
+    result = false;
+
+    ctx.parseDocument();
+    if (ctx.jsonDoc.type() == simdjson::ondemand::json_type::number ||
+        ctx.jsonDoc.type() == simdjson::ondemand::json_type::string ||
+        ctx.jsonDoc.type() == simdjson::ondemand::json_type::boolean ||
+        ctx.jsonDoc.type() == simdjson::ondemand::json_type::null) {
+      result = true;
+    }
+  }
+};
+
+} // namespace facebook::velox::functions

--- a/velox/functions/prestosql/benchmarks/CMakeLists.txt
+++ b/velox/functions/prestosql/benchmarks/CMakeLists.txt
@@ -161,3 +161,8 @@ add_executable(velox_functions_prestosql_benchmarks_cardinality
                CardinalityBenchmark.cpp)
 target_link_libraries(velox_functions_prestosql_benchmarks_cardinality
                       ${BENCHMARK_DEPENDENCIES})
+
+add_executable(velox_functions_benchmarks_simdjson_function_with_expr
+               JsonExprBenchmark.cpp)
+target_link_libraries(velox_functions_benchmarks_simdjson_function_with_expr
+                      ${BENCHMARK_DEPENDENCIES})

--- a/velox/functions/prestosql/benchmarks/JsonBenchmarkUtil.h
+++ b/velox/functions/prestosql/benchmarks/JsonBenchmarkUtil.h
@@ -1,0 +1,31 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#pragma once
+
+#include <folly/Benchmark.h>
+
+namespace facebook::velox::functions::prestosql {
+
+#define ISJSONSCALAR_BENCHMARK_NAMED_PARAM(type, name, iter, jsonSize) \
+  BENCHMARK_RELATIVE_NAMED_PARAM(                                      \
+      name, type##_i_##iter##_jSize_##jsonSize, iter, #jsonSize)
+
+#define ISJSONSCALAR_BENCHMARK_NAMED_PARAM_TWO_FUNCS(             \
+    type, func1, func2, iter, jsonSize)                           \
+  ISJSONSCALAR_BENCHMARK_NAMED_PARAM(type, func1, iter, jsonSize) \
+  ISJSONSCALAR_BENCHMARK_NAMED_PARAM(type, func2, iter, jsonSize)
+
+} // namespace facebook::velox::functions::prestosql

--- a/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
+++ b/velox/functions/prestosql/benchmarks/JsonExprBenchmark.cpp
@@ -1,0 +1,139 @@
+/*
+ * Copyright (c) Facebook, Inc. and its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/**
+ * This file tests the performance of each JsonXXXFunction.call() with
+ * expression framework and Velox vectors.
+ */
+#include <folly/Benchmark.h>
+#include <folly/init/Init.h>
+#include "velox/functions/Registerer.h"
+#include "velox/functions/lib/benchmarks/FunctionBenchmarkBase.h"
+#include "velox/functions/prestosql/JsonFunctions.h"
+#include "velox/functions/prestosql/SIMDJsonFunctions.h"
+#include "velox/functions/prestosql/benchmarks/JsonBenchmarkUtil.h"
+#include "velox/functions/prestosql/registration/RegistrationFunctions.h"
+
+namespace facebook::velox::functions::prestosql {
+namespace {
+
+const std::string smallJson = R"({"k1":"v1"})";
+
+class JsonBenchmark : public velox::functions::test::FunctionBenchmarkBase {
+ public:
+  JsonBenchmark() : FunctionBenchmarkBase() {
+    velox::functions::prestosql::registerJsonFunctions();
+    registerFunction<IsJsonScalarFunction, bool, Json>(
+        {"folly_is_json_scalar"});
+    registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
+        {"simd_is_json_scalar"});
+  }
+
+  std::string prepareData(int jsonSize) {
+    std::string jsonData = R"({"key": [)" + smallJson;
+    for (int i = 0; i < jsonSize / 10; i++) {
+      jsonData += "," + smallJson;
+    }
+    jsonData += "]}";
+    return jsonData;
+  }
+
+  velox::VectorPtr makeJsonData(const std::string& json, int vectorSize) {
+    auto jsonVector =
+        vectorMaker_.flatVector<velox::StringView>(vectorSize, JSON());
+    for (auto i = 0; i < vectorSize; i++) {
+      jsonVector->set(i, velox::StringView(json));
+    }
+    return jsonVector;
+  }
+
+  void runWithJson(
+      int iter,
+      int vectorSize,
+      const std::string& fnName,
+      const std::string& json) {
+    folly::BenchmarkSuspender suspender;
+
+    auto jsonVector = makeJsonData(json, vectorSize);
+
+    auto rowVector = vectorMaker_.rowVector({jsonVector});
+    auto exprSet =
+        compileExpression(fmt::format("{}(c0)", fnName), rowVector->type());
+    suspender.dismiss();
+    doRun(iter, exprSet, rowVector);
+  }
+
+  void doRun(
+      const int iter,
+      velox::exec::ExprSet& exprSet,
+      const velox::RowVectorPtr& rowVector) {
+    uint32_t cnt = 0;
+    for (auto i = 0; i < iter; i++) {
+      cnt += evaluate(exprSet, rowVector)->size();
+    }
+    folly::doNotOptimizeAway(cnt);
+  }
+};
+
+void FollyIsJsonScalar(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJson(iter, vectorSize, "folly_is_json_scalar", json);
+}
+
+void SIMDIsJsonScalar(int iter, int vectorSize, int jsonSize) {
+  folly::BenchmarkSuspender suspender;
+  JsonBenchmark benchmark;
+  auto json = benchmark.prepareData(jsonSize);
+  suspender.dismiss();
+  benchmark.runWithJson(iter, vectorSize, "simd_is_json_scalar", json);
+}
+
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_1k_size, 100, 10);
+BENCHMARK_RELATIVE_NAMED_PARAM(SIMDIsJsonScalar, 100_iters_1k_size, 100, 10);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_10k_size, 100, 100);
+BENCHMARK_RELATIVE_NAMED_PARAM(SIMDIsJsonScalar, 100_iters_10k_size, 100, 100);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_100k_size, 100, 1000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDIsJsonScalar,
+    100_iters_100k_size,
+    100,
+    1000);
+BENCHMARK_DRAW_LINE();
+
+BENCHMARK_NAMED_PARAM(FollyIsJsonScalar, 100_iters_1000k_size, 100, 10000);
+BENCHMARK_RELATIVE_NAMED_PARAM(
+    SIMDIsJsonScalar,
+    100_iters_1000k_size,
+    100,
+    10000);
+BENCHMARK_DRAW_LINE();
+
+} // namespace
+} // namespace facebook::velox::functions::prestosql
+
+int main(int argc, char** argv) {
+  folly::init(&argc, &argv);
+  folly::runBenchmarks();
+  return 0;
+}

--- a/velox/functions/prestosql/registration/CMakeLists.txt
+++ b/velox/functions/prestosql/registration/CMakeLists.txt
@@ -30,7 +30,7 @@ add_library(
   RegistrationFunctions.cpp)
 
 target_link_libraries(velox_functions_prestosql velox_functions_prestosql_impl
-                      velox_is_null_functions)
+                      velox_is_null_functions simdjson)
 
 set_property(TARGET velox_functions_prestosql PROPERTY JOB_POOL_COMPILE
                                                        high_memory_pool)

--- a/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
+++ b/velox/functions/prestosql/registration/JsonFunctionsRegistration.cpp
@@ -16,12 +16,13 @@
 
 #include "velox/functions/Registerer.h"
 #include "velox/functions/prestosql/JsonFunctions.h"
+#include "velox/functions/prestosql/SIMDJsonFunctions.h"
 
 namespace facebook::velox::functions {
 void registerJsonFunctions(const std::string& prefix) {
   registerJsonType();
 
-  registerFunction<IsJsonScalarFunction, bool, Json>(
+  registerFunction<SIMDIsJsonScalarFunction, bool, Json>(
       {prefix + "is_json_scalar"});
   registerFunction<JsonExtractScalarFunction, Varchar, Json, Varchar>(
       {prefix + "json_extract_scalar"});


### PR DESCRIPTION
cherrypick add simdjson build framework (#4598) from https://github.com/facebookincubator/velox

Summary:
For issue https://github.com/facebookincubator/velox/issues/3658. The previous work https://github.com/facebookincubator/velox/pull/4053 shows simdjson can get great performance gain in json function. The design doc is at [4486](https://github.com/facebookincubator/velox/discussions/4486) Add the simdjson library dependency and build system first.

Pull Request resolved: https://github.com/facebookincubator/velox/pull/4598

Reviewed By: Yuhta

Differential Revision: D45778530

Pulled By: kgpai

fbshipit-source-id: 815b8081ccb16e0f2a7c0c64e520de671e19543a