### PR TITLE
Fix parquet write wrong schema  issue

### DIFF
--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -18,6 +18,7 @@
 
 #include <arrow/c/bridge.h> // @manual
 #include <arrow/table.h> // @manual
+#include <arrow/record_batch.h>
 #include <parquet/arrow/writer.h> // @manual
 #include "velox/dwio/parquet/writer/Writer.h"
 
@@ -202,7 +203,7 @@ void Writer::write(const VectorPtr& data) {
   ArrowSchema schema;
   exportToArrow(data, array, generalPool_.get());
   exportToArrow(data, schema);
-  std::shared_ptr<RecordBatch> recordBatch;
+  std::shared_ptr<arrow::RecordBatch> recordBatch;
   if (schema_) {
     PARQUET_ASSIGN_OR_THROW(
         recordBatch, arrow::ImportRecordBatch(&array, schema_));

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -202,14 +202,15 @@ void Writer::write(const VectorPtr& data) {
   ArrowSchema schema;
   exportToArrow(data, array, generalPool_.get());
   exportToArrow(data, schema);
+  std::shared_ptr<RecordBatch> recordBatch;
   if (schema_) {
     PARQUET_ASSIGN_OR_THROW(
-      auto recordBatch, arrow::ImportRecordBatch(&array, schema_));
+        recordBatch, arrow::ImportRecordBatch(&array, schema_));
   } else {
     PARQUET_ASSIGN_OR_THROW(
-      auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
+        recordBatch, arrow::ImportRecordBatch(&array, &schema));
   }
-  
+
   if (!arrowContext_->schema) {
     arrowContext_->schema = recordBatch->schema();
     for (int colIdx = 0; colIdx < arrowContext_->schema->num_fields();

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -17,8 +17,8 @@
 #include "velox/vector/arrow/Bridge.h"
 
 #include <arrow/c/bridge.h> // @manual
-#include <arrow/table.h> // @manual
 #include <arrow/record_batch.h>
+#include <arrow/table.h> // @manual
 #include <parquet/arrow/writer.h> // @manual
 #include "velox/dwio/parquet/writer/Writer.h"
 

--- a/velox/dwio/parquet/writer/Writer.cpp
+++ b/velox/dwio/parquet/writer/Writer.cpp
@@ -199,11 +199,17 @@ void Writer::flush() {
  */
 void Writer::write(const VectorPtr& data) {
   ArrowArray array;
-  // ArrowSchema schema;
+  ArrowSchema schema;
   exportToArrow(data, array, generalPool_.get());
-  // exportToArrow(data, schema);
-  PARQUET_ASSIGN_OR_THROW(
+  exportToArrow(data, schema);
+  if (schema_) {
+    PARQUET_ASSIGN_OR_THROW(
       auto recordBatch, arrow::ImportRecordBatch(&array, schema_));
+  } else {
+    PARQUET_ASSIGN_OR_THROW(
+      auto recordBatch, arrow::ImportRecordBatch(&array, &schema));
+  }
+  
   if (!arrowContext_->schema) {
     arrowContext_->schema = recordBatch->schema();
     for (int colIdx = 0; colIdx < arrowContext_->schema->num_fields();

--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <arrow/type.h>
 #include "velox/dwio/common/Common.h"
 #include "velox/dwio/common/DataBuffer.h"
 #include "velox/dwio/common/DataSink.h"
@@ -53,11 +54,13 @@ class Writer : public dwio::common::Writer {
   Writer(
       std::unique_ptr<dwio::common::DataSink> sink,
       const WriterOptions& options,
-      std::shared_ptr<memory::MemoryPool> pool);
+      std::shared_ptr<memory::MemoryPool> pool,
+      std::shared_ptr<arrow::Schema> schema = nullptr);
 
   Writer(
       std::unique_ptr<dwio::common::DataSink> sink,
-      const WriterOptions& options);
+      const WriterOptions& options,
+      std::shared_ptr<arrow::Schema> schema = nullptr);
 
   static bool isArrowCodecAvailable(dwio::common::CompressionKind compression);
 
@@ -90,6 +93,8 @@ class Writer : public dwio::common::Writer {
   std::shared_ptr<ArrowDataBufferSink> stream_;
 
   std::shared_ptr<ArrowContext> arrowContext_;
+
+  std::shared_ptr<arrow::Schema> schema_;
 };
 
 class ParquetWriterFactory : public dwio::common::WriterFactory {


### PR DESCRIPTION
Currently the velox parquet writer schema info is wrong. This PR pass the schema from java side to velox parquet writer.