### PR TITLE
Use int96 write timestamp type

### DIFF
--- a/velox/dwio/parquet/writer/Writer.h
+++ b/velox/dwio/parquet/writer/Writer.h
@@ -39,6 +39,7 @@ struct WriterOptions {
   int64_t maxRowGroupLength = 1'024 * 1'024;
   int64_t dictionaryPageSizeLimit = 1'024 * 1'024;
   double bufferGrowRatio = 1;
+  bool writeTimestampAsInt96 = false;
   dwio::common::CompressionKind compression =
       dwio::common::CompressionKind_NONE;
   velox::memory::MemoryPool* memoryPool;
@@ -78,6 +79,8 @@ class Writer : public dwio::common::Writer {
   void close();
 
  private:
+  void initlizeParquetWriterIfNecessary();
+
   const int64_t rowsInRowGroup_;
   const int64_t bytesInRowGroup_;
   const double bufferGrowRatio_;


### PR DESCRIPTION
It seems velox does not support read timestamp with INT64 TIMESTAMP_MICROS or TIMESTAMP_MILLIS. So I hardcode it that always use int96 to write timestamp type. This is also the vanilla Spark default behavior.

For example:
```scala
import org.apache.spark.sql._
import org.apache.spark.sql.types._

val data = (1 to 10).map(i => Row(Decimal(i, 18, 0), new java.sql.Timestamp(i)))
val schema = StructType(List(StructField("d", DecimalType(18, 0), false), StructField("time", TimestampType, false)).toArray)
val df = spark.createDataFrame(sc.parallelize(data), schema)
spark.sql("set spark.sql.parquet.outputTimestampType=TIMESTAMP_MICROS")
df.write.format("parquet").mode("overwrite").save("test")
```

```scala
spark.read.parquet("test").collect

Caused by: java.lang.RuntimeException: Exception: VeloxRuntimeError
Error Source: RUNTIME
Error Code: NOT_IMPLEMENTED
Retriable: False
Context: Split [Hive: file:///spark-3.3.1.13-bin-netease/test/part-00000-6f9134c8-32c0-4909-ab1a-00277d68cf8f-c000.snappy.parquet 0 - 835] Task Gluten stage-4 task-4
Top-Level Context: Same as context.
Function: readInt128
File: ../.././velox/dwio/common/IntDecoder.h
Line: 555
Stack trace:
```

This is the part of https://github.com/oap-project/gluten/pull/2379