### PR TITLE
[VL] [Bug fix] support min max aggregation with varbinary type

### DIFF
--- a/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
+++ b/velox/functions/prestosql/aggregates/MinMaxAggregates.cpp
@@ -508,6 +508,7 @@ exec::AggregateRegistrationResult registerMinMax(const std::string& name) {
           case TypeKind::HUGEINT:
             return std::make_unique<TNumeric<int128_t>>(resultType);
           case TypeKind::VARCHAR:
+          case TypeKind::VARBINARY:
           case TypeKind::ARRAY:
           case TypeKind::MAP:
           case TypeKind::ROW:

--- a/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
+++ b/velox/functions/prestosql/aggregates/tests/MinMaxTest.cpp
@@ -119,6 +119,10 @@ TEST_F(MinMaxTest, maxVarchar) {
   doTest(max, VARCHAR());
 }
 
+TEST_F(MinMaxTest, maxVarbinary) {
+  doTest(max, VARBINARY());
+}
+
 TEST_F(MinMaxTest, maxBoolean) {
   doTest(max, BOOLEAN());
 }
@@ -157,6 +161,10 @@ TEST_F(MinMaxTest, minInterval) {
 
 TEST_F(MinMaxTest, minVarchar) {
   doTest(min, VARCHAR());
+}
+
+TEST_F(MinMaxTest, minVarbinary) {
+  doTest(min, VARBINARY());
 }
 
 TEST_F(MinMaxTest, minBoolean) {


### PR DESCRIPTION
support min max aggregation with varbinary type. #385 https://github.com/oap-project/gluten/issues/2169

Gluten CI:https://github.com/oap-project/gluten/pull/2649