### PR TITLE
Make build of velox_hive_connector STATIC

### DIFF
--- a/velox/connectors/hive/CMakeLists.txt
+++ b/velox/connectors/hive/CMakeLists.txt
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 add_library(
-  velox_hive_connector OBJECT
+  velox_hive_connector
   FileHandle.cpp
   HiveConfig.cpp
   HiveConnector.cpp


### PR DESCRIPTION
As mentioned in the issue #390, libvelox_hive_connector.a generation is not static, since OBJECT label is added to the add_library. This PR fixes this and unblocks build of Gluten.

This PR fixes #390 