### PR TITLE
Fix compile issue for split function

### DIFF
--- a/velox/functions/lib/Re2Functions.cpp
+++ b/velox/functions/lib/Re2Functions.cpp
@@ -1178,8 +1178,7 @@ re2ExtractAllSignatures() {
 
 std::shared_ptr<VectorFunction> makeRe2SplitAll(
     const std::string& name,
-    const std::vector<VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& /*config*/) {
+    const std::vector<VectorFunctionArg>& inputArgs) {
   auto numArgs = inputArgs.size();
   VELOX_USER_CHECK(
       numArgs == 2, "{} requires 2 arguments, but got {}", name, numArgs);

--- a/velox/functions/lib/Re2Functions.h
+++ b/velox/functions/lib/Re2Functions.h
@@ -140,8 +140,7 @@ std::vector<std::shared_ptr<exec::FunctionSignature>> re2ExtractAllSignatures();
 /// If the pattern does not match, returns original string as array.
 std::shared_ptr<exec::VectorFunction> makeRe2SplitAll(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& config);
+    const std::vector<exec::VectorFunctionArg>& inputArgs);
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> re2SplitAllSignatures();
 

--- a/velox/functions/sparksql/SplitFunctions.cpp
+++ b/velox/functions/sparksql/SplitFunctions.cpp
@@ -29,9 +29,8 @@ namespace {
 ///     values (if provided).
 std::shared_ptr<exec::VectorFunction> createSplit(
     const std::string& name,
-    const std::vector<exec::VectorFunctionArg>& inputArgs,
-    const core::QueryConfig& config) {
-  return makeRe2SplitAll(name, inputArgs, config);
+    const std::vector<exec::VectorFunctionArg>& inputArgs) {
+  return makeRe2SplitAll(name, inputArgs);
 }
 
 std::vector<std::shared_ptr<exec::FunctionSignature>> signatures() {


### PR DESCRIPTION
Failed to compile wip_func_bp branch, due to inconsistent API of vector function factory between this branch and upstream.