### PR TITLE
Fix type in decimal_avg and decimal_sum while spilling

### DIFF
--- a/velox/functions/sparksql/aggregates/DecimalAvgAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalAvgAggregate.h
@@ -223,7 +223,7 @@ class DecimalAverageAggregate : public exec::Aggregate {
       bool /* mayPushdown */) override {
     decodedPartial_.decode(*args[0], rows);
     auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
-    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TInputType>>();
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TSumResultType>>();
     auto countVector = baseRowVector->childAt(1)->as<SimpleVector<int64_t>>();
 
     if (decodedPartial_.isConstantMapping()) {

--- a/velox/functions/sparksql/aggregates/DecimalAvgAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalAvgAggregate.h
@@ -223,7 +223,8 @@ class DecimalAverageAggregate : public exec::Aggregate {
       bool /* mayPushdown */) override {
     decodedPartial_.decode(*args[0], rows);
     auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
-    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TSumResultType>>();
+    auto sumVector =
+        baseRowVector->childAt(0)->as<SimpleVector<TSumResultType>>();
     auto countVector = baseRowVector->childAt(1)->as<SimpleVector<int64_t>>();
 
     if (decodedPartial_.isConstantMapping()) {

--- a/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
+++ b/velox/functions/sparksql/aggregates/DecimalSumAggregate.h
@@ -304,7 +304,7 @@ class DecimalSumAggregate : public exec::Aggregate {
     VELOX_CHECK_EQ(
         decodedPartial_.base()->encoding(), VectorEncoding::Simple::ROW);
     auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
-    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TInputType>>();
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<TResultType>>();
     auto isEmptyVector = baseRowVector->childAt(1)->as<SimpleVector<bool>>();
     if (decodedPartial_.isConstantMapping()) {
       if (!decodedPartial_.isNullAt(0)) {


### PR DESCRIPTION
We have been playing around with spill in partial aggregate when we noticed velox crashes when it read data back from spill in partial aggregate. This happens when input type is of `ShortDecimal` like `decimal(12,4)`. 
Both these agg function produces intermediate `sum` of `LongDecimal` irrespective of input. So when input is of `LongDecimal` it works but in case of `ShortDecimal` this respective dynamic type cast fails producing null pointer causing crash.