### PR TITLE
Add tokenizer factory to support plugin custom tokenizer (7484)

### DIFF
--- a/velox/type/Subfield.cpp
+++ b/velox/type/Subfield.cpp
@@ -18,21 +18,19 @@
 
 namespace facebook::velox::common {
 
-Subfield::Subfield(
-    const std::string& path,
-    const std::shared_ptr<Separators>& separators) {
-  Tokenizer tokenizer(path, separators);
-  VELOX_CHECK(tokenizer.hasNext(), "Column name is missing: {}", path);
+Subfield::Subfield(const std::string& path) {
+  auto tokenizer = Tokenizer::getInstance(path);
+  VELOX_CHECK(tokenizer->hasNext(), "Column name is missing: {}", path);
 
-  auto firstElement = tokenizer.next();
+  auto firstElement = tokenizer->next();
   VELOX_CHECK(
       firstElement->kind() == kNestedField,
       "Subfield path must start with a name: {}",
       path);
   std::vector<std::unique_ptr<PathElement>> pathElements;
   pathElements.push_back(std::move(firstElement));
-  while (tokenizer.hasNext()) {
-    pathElements.push_back(tokenizer.next());
+  while (tokenizer->hasNext()) {
+    pathElements.push_back(tokenizer->next());
   }
   path_ = std::move(pathElements);
 }

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -45,7 +45,7 @@ struct Separators {
 
   char backSlash = '\\';
   char closeBracket = ']';
-  char dot = '\0';
+  char dot = '.';
   char openBracket = '[';
   char quote = '\"';
   char wildCard = '*';

--- a/velox/type/Subfield.h
+++ b/velox/type/Subfield.h
@@ -218,10 +218,7 @@ class Subfield {
   };
 
  public:
-  // Separators: the customized separators to tokenize field name.
-  explicit Subfield(
-      const std::string& path,
-      const std::shared_ptr<Separators>& separators = Separators::get());
+  explicit Subfield(const std::string& path);
 
   explicit Subfield(std::vector<std::unique_ptr<PathElement>>&& path);
 

--- a/velox/type/Tokenizer.h
+++ b/velox/type/Tokenizer.h
@@ -35,14 +35,30 @@ class Tokenizer {
     kFailed,
   };
 
-  // Separators: the customized separators to tokenize field name.
-  explicit Tokenizer(
-      const std::string& path,
-      const std::shared_ptr<Separators>& separators);
+  virtual ~Tokenizer() = default;
 
-  bool hasNext();
+  virtual bool hasNext() = 0;
 
-  std::unique_ptr<Subfield::PathElement> next();
+  virtual std::unique_ptr<Subfield::PathElement> next() = 0;
+
+  static std::unique_ptr<Tokenizer> getInstance(const std::string& path);
+
+  static void registerInstanceFactory(
+      std::function<std::unique_ptr<Tokenizer>(const std::string&)>
+          tokenizerFactory);
+
+ private:
+  static std::function<std::unique_ptr<Tokenizer>(const std::string&)>
+      tokenizerFactory_;
+};
+
+class DefaultTokenizer : public Tokenizer {
+ public:
+  explicit DefaultTokenizer(const std::string& path);
+
+  bool hasNext() override;
+
+  std::unique_ptr<Subfield::PathElement> next() override;
 
  private:
   const std::string path_;


### PR DESCRIPTION
48886bd83621e1e11220a64f50076a052fd5d36c affects below unit test. Revert it and use customized tokenizer registered from Gluten.

```
200 - velox_type_test (Failed)
212 - velox_dwio_common_test (Failed)
247 - velox_dwrf_e2e_filter_test (Failed)
262 - velox_parquet_e2e_filter_test (Failed)
284 - velox_hive_connector_test (Failed)
288 - velox_exec_test (Failed)
```