### PR TITLE
Fix decimal agg signature on partial companion function

### DIFF
--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -429,7 +429,9 @@ exec::AggregateRegistrationResult registerAverage(
                 auto inputScale = inputType->asShortDecimal().scale();
                 auto sumType =
                     DECIMAL(std::min(38, inputPrecision + 10), inputScale);
-                if (exec::isPartialOutput(step)) {
+                if (exec::isPartialOutput(step) ||
+                    (step == core::AggregationNode::Step::kSingle &&
+                     resultType->isRow())) {
                   return std::make_unique<
                       DecimalAverageAggregate<int64_t, int64_t>>(
                       resultType, sumType);

--- a/velox/functions/sparksql/aggregates/SumAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/SumAggregate.cpp
@@ -29,7 +29,13 @@ using SumAggregate = SumAggregateBase<TInput, TAccumulator, ResultType, true>;
 TypePtr getDecimalSumType(
     const TypePtr& resultType,
     core::AggregationNode::Step step) {
-  return exec::isPartialOutput(step) ? resultType->childAt(0) : resultType;
+  if (exec::isPartialOutput(step)) {
+    return resultType->childAt(0);
+  }
+  if (step == core::AggregationNode::Step::kSingle && resultType->isRow()) {
+    return resultType->childAt(0);
+  }
+  return resultType;
 }
 } // namespace
 


### PR DESCRIPTION
We start to use partial companion functions of Final step. According to https://github.com/facebookincubator/velox/blob/main/velox/exec/AggregateInfo.cpp#L111-L112, Final step will be mapped to Single.
Refer to https://github.com/facebookincubator/velox/issues/6506#issuecomment-1750369714 for details.