### PR TITLE
Fix build error

### DIFF
--- a/velox/exec/tests/SharedArbitratorTest.cpp
+++ b/velox/exec/tests/SharedArbitratorTest.cpp
@@ -1177,7 +1177,8 @@ TEST_F(SharedArbitrationTest, reclaimFromDistinctAggregation) {
 
 TEST_F(SharedArbitrationTest, reclaimFromPartialAggregation) {
   const uint64_t maxQueryCapacity = 20L << 20;
-  std::vector<RowVectorPtr> vectors = newVectors(1024, maxQueryCapacity * 2);
+  std::vector<RowVectorPtr> vectors =
+      createVectors(rowType_, 1024, maxQueryCapacity * 2);
   createDuckDbTable(vectors);
   const auto spillDirectory = exec::test::TempDirectoryPath::create();
   core::PlanNodeId partialAggNodeId;


### PR DESCRIPTION
Due to the changes brought by https://github.com/oap-project/velox/commit/ab15325df5fed9c032bb59c9875ef6880aaff55b, we need to adapt to this change in `Enable spilling for partial aggregation (7558)`.