### PR TITLE
[Gluten-1.2] Port #10646 to Branch-1.2 for Put cheap check first in testingTriggerSpill() (#10646)

### DIFF
--- a/velox/exec/Spill.cpp
+++ b/velox/exec/Spill.cpp
@@ -338,11 +338,7 @@ tsan_atomic<uint32_t>& injectedSpillCount() {
 }
 
 bool testingTriggerSpill(const std::string& pool) {
-  // Do not evaluate further if trigger is not set.
-  if (!pool.empty() && !RE2::FullMatch(pool, testingSpillPoolRegExp())) {
-    return false;
-  }
-
+  // Put cheap check first to reduce CPU consumption in release code.
   if (testingSpillPct() <= 0) {
     return false;
   }
@@ -352,6 +348,10 @@ bool testingTriggerSpill(const std::string& pool) {
   }
 
   if (folly::Random::rand32() % 100 > testingSpillPct()) {
+    return false;
+  }
+
+  if (!pool.empty() && !RE2::FullMatch(pool, testingSpillPoolRegExp())) {
     return false;
   }
 


### PR DESCRIPTION
Summary:
testingTriggerSpill() uses 1% cpu in meta internal profiling on release build. This is due to the expensive regex check it does upon entrance of this method. Move pct check up to avoid regex check to reduce the cpu consumption.

Pull Request resolved: https://github.com/facebookincubator/velox/pull/10646

Reviewed By: kevinwilfong

Differential Revision: D60613614

Pulled By: tanjialiang

fbshipit-source-id: 23cbfc89b575343b7e7da1dd7d0eaef63a1ec705