### PR TITLE
[Branch-1.2] Upgrade cmake to meet Velox build requirement

### DIFF
--- a/scripts/setup-centos7.sh
+++ b/scripts/setup-centos7.sh
@@ -54,7 +54,7 @@ function wget_and_untar {
 
 function install_cmake {
   cd "${DEPENDENCY_DIR}"
-  wget_and_untar https://cmake.org/files/v3.25/cmake-3.25.1.tar.gz cmake-3
+  wget_and_untar https://cmake.org/files/v3.28/cmake-3.28.3.tar.gz cmake-3
   cd cmake-3
   ./bootstrap --prefix=/usr/local
   make -j$(nproc)


### PR DESCRIPTION
The minimum cmake version required by Velox is 3.28. We should upgrade it to fix failure in Gluten dynamic build path.