### PR TITLE
Fix MergeJoinTest Build failing due to duplicate test

### DIFF
--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -1851,48 +1851,43 @@ TEST_F(MergeJoinTest, barrier) {
   }
 }
 
-TEST_F(MergeJoinTest, fullOuterJoinWithDuplicateMatch) {
-    // Each row on the left side has at most one match on the right side.
-    auto left = makeRowVector(
-        {"a", "b"},
-        {
-            makeNullableFlatVector<int32_t>({1, 2, 2, 2, 3, 5, 6, std::nullopt}),
-            makeNullableFlatVector<double>(
-                {2.0, 100.0, 1.0, 1.0, 3.0, 1.0, 6.0, std::nullopt}),
-        });
-  
-    auto right = makeRowVector(
-        {"c", "d"},
-        {
-            makeNullableFlatVector<int32_t>(
-                {0, 2, 2, 2, 2, 3, 4, 5, 7, std::nullopt}),
-            makeNullableFlatVector<double>(
-                {0.0, 3.0, -1.0, -1.0, 3.0, 2.0, 1.0, 3.0, 7.0, std::nullopt}),
-        });
-  
-    createDuckDbTable("t", {left});
-    createDuckDbTable("u", {right});
-  
-    auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  
-    auto rightPlan =
-        PlanBuilder(planNodeIdGenerator)
-            .values({left})
-            .mergeJoin(
-                {"a"},
-                {"c"},
-                PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-                "b < d",
-                {"a", "b", "c", "d"},
-                core::JoinType::kFull)
-            .planNode();
-    AssertQueryBuilder(rightPlan, duckDbQueryRunner_)
-        .assertResults("SELECT * from t FULL OUTER JOIN u ON a = c AND b < d");
-  }
+TEST_F(
+  MergeJoinTest,
+  antiJoinWithFilterWithMultiMatchedRowsInDifferentBatches) {
+  auto left =
+    makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3})});
 
-  TEST_F(
-    MergeJoinTest,
-    antiJoinWithFilterWithMultiMatchedRowsInDifferentBatches) {
+  auto right =
+    makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 3})});
+
+  createDuckDbTable("t", {left});
+  createDuckDbTable("u", {right});
+
+  // Anti join.
+  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
+  auto plan = PlanBuilder(planNodeIdGenerator)
+                .values({split(left, 2)})
+                .mergeJoin(
+                    {"t0"},
+                    {"u0"},
+                    PlanBuilder(planNodeIdGenerator)
+                        .values(split(right, 2))
+                        .planNode(),
+                    "t0 > 2",
+                    {"t0"},
+                    core::JoinType::kAnti)
+                .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+    .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
+    .config(core::QueryConfig::kMaxOutputBatchRows, "2")
+    .assertResults(
+        "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
+}
+
+TEST_F(
+  MergeJoinTest,
+  antiJoinWithFilterWithMultiMatchedRowsInDifferentBatches) {
   auto left =
       makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3})});
 
@@ -1904,50 +1899,23 @@ TEST_F(MergeJoinTest, fullOuterJoinWithDuplicateMatch) {
 
   // Anti join.
   auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan = PlanBuilder(planNodeIdGenerator)
-                  .values({split(left, 2)})
-                  .mergeJoin(
-                      {"t0"},
-                      {"u0"},
-                      PlanBuilder(planNodeIdGenerator)
-                          .values(split(right, 2))
-                          .planNode(),
-                      "t0 > 2",
-                      {"t0"},
-                      core::JoinType::kAnti)
-                  .planNode();
+  auto plan =
+      PlanBuilder(planNodeIdGenerator)
+          .values({split(left, 2)})
+          .mergeJoin(
+              {"t0"},
+              {"u0"},
+              PlanBuilder(planNodeIdGenerator)
+                  .values(split(right, 2))
+                  .planNode(),
+                  "t0 > 2",
+                  {"t0"},
+                  core::JoinType::kAnti)
+              .planNode();
 
   AssertQueryBuilder(plan, duckDbQueryRunner_)
       .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
       .config(core::QueryConfig::kMaxOutputBatchRows, "2")
-      .assertResults(
-          "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
-}
-
-TEST_F(MergeJoinTest, antiJoinWithFilterWithMultiMatchedRows) {
-  auto left = makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2})});
-
-  auto right =
-      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 2, 2})});
-
-  createDuckDbTable("t", {left});
-  createDuckDbTable("u", {right});
-
-  // Anti join.
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .values({left})
-          .mergeJoin(
-              {"t0"},
-              {"u0"},
-              PlanBuilder(planNodeIdGenerator).values({right}).planNode(),
-              "t0 > 2",
-              {"t0"},
-              core::JoinType::kAnti)
-          .planNode();
-
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
       .assertResults(
           "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
 }

--- a/velox/exec/tests/MergeJoinTest.cpp
+++ b/velox/exec/tests/MergeJoinTest.cpp
@@ -1885,41 +1885,6 @@ TEST_F(
         "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
 }
 
-TEST_F(
-  MergeJoinTest,
-  antiJoinWithFilterWithMultiMatchedRowsInDifferentBatches) {
-  auto left =
-      makeRowVector({"t0"}, {makeNullableFlatVector<int64_t>({1, 2, 3})});
-
-  auto right =
-      makeRowVector({"u0"}, {makeNullableFlatVector<int64_t>({1, 2, 3})});
-
-  createDuckDbTable("t", {left});
-  createDuckDbTable("u", {right});
-
-  // Anti join.
-  auto planNodeIdGenerator = std::make_shared<core::PlanNodeIdGenerator>();
-  auto plan =
-      PlanBuilder(planNodeIdGenerator)
-          .values({split(left, 2)})
-          .mergeJoin(
-              {"t0"},
-              {"u0"},
-              PlanBuilder(planNodeIdGenerator)
-                  .values(split(right, 2))
-                  .planNode(),
-                  "t0 > 2",
-                  {"t0"},
-                  core::JoinType::kAnti)
-              .planNode();
-
-  AssertQueryBuilder(plan, duckDbQueryRunner_)
-      .config(core::QueryConfig::kPreferredOutputBatchRows, "2")
-      .config(core::QueryConfig::kMaxOutputBatchRows, "2")
-      .assertResults(
-          "SELECT t0 FROM t WHERE NOT exists (select 1 from u where t0 = u0 AND t.t0 > 2 ) ");
-}
-
 TEST_F(MergeJoinTest, antiJoinWithTwoJoinKeysInDifferentBatch) {
   auto left = makeRowVector(
       {"a", "b"},


### PR DESCRIPTION
There is a duplicate test causing build failures.

## Fix
Remove the duplicate test