### PR TITLE
feat: support reading DeltaByteArray encoding for Decimals

### DIFF
--- a/velox/connectors/hive/HiveConfig.cpp
+++ b/velox/connectors/hive/HiveConfig.cpp
@@ -230,6 +230,13 @@ bool HiveConfig::readStatsBasedFilterReorderDisabled(
       config_->get<bool>(kReadStatsBasedFilterReorderDisabled, false));
 }
 
+bool HiveConfig::isRequestedTypeCheckEnabled(
+    const config::ConfigBase* session) const {
+  return session->get<bool>(
+      kEnableRequestedTypeCheckSession,
+      config_->get<bool>(kEnableRequestedTypeCheck, true));
+}
+
 std::string HiveConfig::hiveLocalDataPath() const {
   return config_->get<std::string>(kLocalDataPath, "");
 }

--- a/velox/connectors/hive/HiveConfig.h
+++ b/velox/connectors/hive/HiveConfig.h
@@ -187,6 +187,11 @@ class HiveConfig {
   static constexpr const char* kLocalDataPath = "hive_local_data_path";
   static constexpr const char* kLocalFileFormat = "hive_local_file_format";
 
+  static constexpr const char* kEnableRequestedTypeCheck =
+      "enable-requested-type-check";
+  static constexpr const char* kEnableRequestedTypeCheckSession =
+      "enable_requested_type_check";
+
   InsertExistingPartitionsBehavior insertExistingPartitionsBehavior(
       const config::ConfigBase* session) const;
 
@@ -257,6 +262,10 @@ class HiveConfig {
   /// Returns true if the stats based filter reorder for read is disabled.
   bool readStatsBasedFilterReorderDisabled(
       const config::ConfigBase* session) const;
+
+  /// Whether to enable requested type check in the ReaderBase::convertType.
+  /// Returns true by default.
+  bool isRequestedTypeCheckEnabled(const config::ConfigBase* session) const;
 
   /// Returns the file system path containing local data. If non-empty,
   /// initializes LocalHiveConnectorMetadata to provide metadata for the tables

--- a/velox/connectors/hive/HiveConnectorUtil.cpp
+++ b/velox/connectors/hive/HiveConnectorUtil.cpp
@@ -604,6 +604,8 @@ void configureReaderOptions(
     }
 
     readerOptions.setFileFormat(hiveSplit->fileFormat);
+    readerOptions.setEnableRequestedTypeCheck(
+        hiveConfig->isRequestedTypeCheckEnabled(sessionProperties));
   }
 }
 

--- a/velox/connectors/hive/SplitReader.cpp
+++ b/velox/connectors/hive/SplitReader.cpp
@@ -413,11 +413,17 @@ std::vector<TypePtr> SplitReader::adaptColumns(
       auto fileTypeIdx = fileType->getChildIdxIfExists(fieldName);
       if (!fileTypeIdx.has_value()) {
         // Column is missing. Most likely due to schema evolution.
-        VELOX_CHECK(tableSchema, "Unable to resolve column '{}'", fieldName);
+        auto outputTypeIdx = readerOutputType_->getChildIdxIfExists(fieldName);
+        TypePtr fieldType;
+        if (outputTypeIdx.has_value()) {
+          // Field name exists in the user-specified output type.
+          fieldType = readerOutputType_->childAt(outputTypeIdx.value());
+        } else {
+          VELOX_CHECK(tableSchema, "Unable to resolve column '{}'", fieldName);
+          fieldType = tableSchema->findChild(fieldName);
+        }
         childSpec->setConstantValue(BaseVector::createNullConstant(
-            tableSchema->findChild(fieldName),
-            1,
-            connectorQueryCtx_->memoryPool()));
+            fieldType, 1, connectorQueryCtx_->memoryPool()));
       } else {
         // Column no longer missing, reset constant value set on the spec.
         childSpec->setConstantValue(nullptr);

--- a/velox/docs/configs.rst
+++ b/velox/docs/configs.rst
@@ -676,6 +676,11 @@ Each query can override the config by setting corresponding query session proper
      - bool
      - true
      - Reads timestamp partition value as local time if true. Otherwise, reads as UTC.
+   * - enable-requested-type-check
+     - enable_requested_type_check
+     - bool
+     - true
+     - Whether to enable requested type check in the `ReaderBase::convertType`. True by default.
 
 ``ORC File Format Configuration``
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/velox/dwio/common/Options.h
+++ b/velox/dwio/common/Options.h
@@ -629,6 +629,10 @@ class ReaderOptions : public io::ReaderOptions {
     return randomSkip_;
   }
 
+  bool enableRequestedTypeCheck() const {
+    return enableRequestedTypeCheck_;
+  }
+
   void setRandomSkip(std::shared_ptr<random::RandomSkipTracker> randomSkip) {
     randomSkip_ = std::move(randomSkip);
   }
@@ -665,6 +669,10 @@ class ReaderOptions : public io::ReaderOptions {
     allowEmptyFile_ = value;
   }
 
+  void setEnableRequestedTypeCheck(bool enableRequestedTypeCheck) {
+    enableRequestedTypeCheck_ = enableRequestedTypeCheck;
+  }
+
  private:
   uint64_t tailLocation_;
   FileFormat fileFormat_;
@@ -682,6 +690,7 @@ class ReaderOptions : public io::ReaderOptions {
   bool adjustTimestampToTimezone_{false};
   bool selectiveNimbleReaderEnabled_{false};
   bool allowEmptyFile_{false};
+  bool enableRequestedTypeCheck_{true};
 };
 
 struct WriterOptions {

--- a/velox/dwio/common/ScanSpec.cpp
+++ b/velox/dwio/common/ScanSpec.cpp
@@ -142,7 +142,7 @@ bool ScanSpec::hasFilter() const {
   if (hasFilter_.has_value()) {
     return hasFilter_.value();
   }
-  if (!isConstant() && filter()) {
+  if (filter()) {
     hasFilter_ = true;
     return true;
   }

--- a/velox/dwio/common/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/common/SelectiveStructColumnReader.cpp
@@ -358,7 +358,6 @@ void SelectiveStructColumnReaderBase::read(
   }
 
   const auto& childSpecs = scanSpec_->children();
-  VELOX_CHECK(!childSpecs.empty());
   for (size_t i = 0; i < childSpecs.size(); ++i) {
     const auto& childSpec = childSpecs[i];
     VELOX_TRACE_HISTORY_PUSH("read %s", childSpec->fieldName().c_str());
@@ -458,15 +457,17 @@ bool SelectiveStructColumnReaderBase::isChildMissing(
                                                   // row type that doesn't exist
                                                   // in the output.
        fileType_->type()->kind() !=
-           TypeKind::MAP && // If this is the case it means this is a flat map,
-                            // so it can't have "missing" fields.
-       childSpec.channel() >= fileType_->size());
+           TypeKind::MAP // If this is the case it means this is a flat map,
+                         // so it can't have "missing" fields.
+       ) &&
+      (columnReaderOptions_.useColumnNamesForColumnMapping_
+           ? !asRowType(fileType_->type())->containsChild(childSpec.fieldName())
+           : childSpec.channel() >= fileType_->size());
 }
 
 void SelectiveStructColumnReaderBase::getValues(
     const RowSet& rows,
     VectorPtr* result) {
-  VELOX_CHECK(!scanSpec_->children().empty());
   VELOX_CHECK_NOT_NULL(
       *result, "SelectiveStructColumnReaderBase expects a non-null result");
   VELOX_CHECK(

--- a/velox/dwio/common/SelectiveStructColumnReader.h
+++ b/velox/dwio/common/SelectiveStructColumnReader.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include "velox/dwio/common/Options.h"
 #include "velox/dwio/common/SelectiveColumnReaderInternal.h"
 
 namespace facebook::velox::dwio::common {
@@ -111,6 +112,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
   static constexpr int32_t kConstantChildSpecSubscript = -1;
 
   SelectiveStructColumnReaderBase(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       FormatParams& params,
@@ -118,6 +120,7 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       bool isRoot = false,
       bool generateLazyChildren = true)
       : SelectiveColumnReader(requestedType, fileType, params, scanSpec),
+        columnReaderOptions_(columnReaderOptions),
         debugString_(
             getExceptionContext().message(VeloxException::Type::kSystem)),
         isRoot_(isRoot),
@@ -154,6 +157,8 @@ class SelectiveStructColumnReaderBase : public SelectiveColumnReader {
       setOutputRows(rows);
     }
   }
+
+  const dwio::common::ColumnReaderOptions& columnReaderOptions_;
 
   // Context information obtained from ExceptionContext. Stored here
   // so that LazyVector readers under this can add this to their

--- a/velox/dwio/dwrf/reader/ReaderBase.cpp
+++ b/velox/dwio/dwrf/reader/ReaderBase.cpp
@@ -344,13 +344,19 @@ std::shared_ptr<const Type> ReaderBase::convertType(
       return SMALLINT();
     case TypeKind::INTEGER:
       return INTEGER();
-    case TypeKind::BIGINT:
+    case TypeKind::BIGINT: {
+      TypePtr converted;
       if (type.format() == DwrfFormat::kOrc &&
           type.getOrcPtr()->kind() == proto::orc::Type_Kind_DECIMAL) {
-        return DECIMAL(
-            type.getOrcPtr()->precision(), type.getOrcPtr()->scale());
+        converted =
+            DECIMAL(type.getOrcPtr()->precision(), type.getOrcPtr()->scale());
+      } else {
+        converted = BIGINT();
+        common::testutil::TestValue::adjust(
+            "facebook::velox::dwrf::ReaderBase::convertType", &converted);
       }
-      return BIGINT();
+      return converted;
+    }
     case TypeKind::HUGEINT:
       if (type.format() == DwrfFormat::kOrc &&
           type.getOrcPtr()->kind() == proto::orc::Type_Kind_DECIMAL) {

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.cpp
@@ -75,16 +75,17 @@ void SelectiveDecimalColumnReader<DataT>::seekToRowGroup(int64_t index) {
 
 template <typename DataT>
 template <bool kDense>
-void SelectiveDecimalColumnReader<DataT>::readHelper(RowSet rows) {
-  vector_size_t numRows = rows.back() + 1;
+void SelectiveDecimalColumnReader<DataT>::readHelper(
+    const common::Filter* filter,
+    RowSet rows) {
   ExtractToReader extractValues(this);
-  common::AlwaysTrue filter;
+  common::AlwaysTrue alwaysTrue;
   DirectRleColumnVisitor<
       int64_t,
       common::AlwaysTrue,
       decltype(extractValues),
       kDense>
-      visitor(filter, this, rows, extractValues);
+      visitor(alwaysTrue, this, rows, extractValues);
 
   // decode scale stream
   if (version_ == velox::dwrf::RleVersion_1) {
@@ -104,14 +105,161 @@ void SelectiveDecimalColumnReader<DataT>::readHelper(RowSet rows) {
   // reset numValues_ before reading values
   numValues_ = 0;
   valueSize_ = sizeof(DataT);
+  vector_size_t numRows = rows.back() + 1;
   ensureValuesCapacity<DataT>(numRows);
 
   // decode value stream
   facebook::velox::dwio::common::
       ColumnVisitor<DataT, common::AlwaysTrue, decltype(extractValues), kDense>
-          valueVisitor(filter, this, rows, extractValues);
+          valueVisitor(alwaysTrue, this, rows, extractValues);
   decodeWithVisitor<DirectDecoder<true>>(valueDecoder_.get(), valueVisitor);
   readOffset_ += numRows;
+
+  // Fill decimals before applying filter.
+  fillDecimals();
+
+  const auto rawNulls = nullsInReadRange_
+      ? (kDense ? nullsInReadRange_->as<uint64_t>() : rawResultNulls_)
+      : nullptr;
+  // Process filter.
+  process(filter, rows, rawNulls);
+}
+
+template <typename DataT>
+void SelectiveDecimalColumnReader<DataT>::processNulls(
+    bool isNull,
+    const RowSet& rows,
+    const uint64_t* rawNulls) {
+  if (!rawNulls) {
+    return;
+  }
+  returnReaderNulls_ = false;
+  anyNulls_ = !isNull;
+  allNull_ = isNull;
+
+  auto rawDecimal = values_->asMutable<DataT>();
+  auto rawScale = scaleBuffer_->asMutable<int64_t>();
+
+  vector_size_t idx = 0;
+  if (isNull) {
+    for (vector_size_t i = 0; i < numValues_; i++) {
+      if (bits::isBitNull(rawNulls, i)) {
+        bits::setNull(rawResultNulls_, idx);
+        addOutputRow(rows[i]);
+        idx++;
+      }
+    }
+  } else {
+    for (vector_size_t i = 0; i < numValues_; i++) {
+      if (!bits::isBitNull(rawNulls, i)) {
+        bits::setNull(rawResultNulls_, idx, false);
+        rawDecimal[idx] = rawDecimal[i];
+        rawScale[idx] = rawScale[i];
+        addOutputRow(rows[i]);
+        idx++;
+      }
+    }
+  }
+}
+
+template <typename DataT>
+void SelectiveDecimalColumnReader<DataT>::processFilter(
+    const common::Filter* filter,
+    const RowSet& rows,
+    const uint64_t* rawNulls) {
+  VELOX_CHECK_NOT_NULL(filter, "Filter must not be null.");
+  returnReaderNulls_ = false;
+  anyNulls_ = false;
+  allNull_ = true;
+
+  vector_size_t idx = 0;
+  auto rawDecimal = values_->asMutable<DataT>();
+  for (vector_size_t i = 0; i < numValues_; i++) {
+    if (rawNulls && bits::isBitNull(rawNulls, i)) {
+      if (filter->testNull()) {
+        bits::setNull(rawResultNulls_, idx);
+        addOutputRow(rows[i]);
+        anyNulls_ = true;
+        idx++;
+      }
+    } else {
+      bool tested;
+      if constexpr (std::is_same_v<DataT, int64_t>) {
+        tested = filter->testInt64(rawDecimal[i]);
+      } else {
+        tested = filter->testInt128(rawDecimal[i]);
+      }
+
+      if (tested) {
+        if (rawNulls) {
+          bits::setNull(rawResultNulls_, idx, false);
+        }
+        rawDecimal[idx] = rawDecimal[i];
+        addOutputRow(rows[i]);
+        allNull_ = false;
+        idx++;
+      }
+    }
+  }
+}
+
+template <typename DataT>
+void SelectiveDecimalColumnReader<DataT>::process(
+    const common::Filter* filter,
+    const RowSet& rows,
+    const uint64_t* rawNulls) {
+  // Treat the filter as kAlwaysTrue if any of the following conditions are met:
+  // 1) No filter found;
+  // 2) Filter is kIsNotNull but rawNulls == NULL (no elements is null).
+  auto filterKind =
+      !filter || (filter->kind() == common::FilterKind::kIsNotNull && !rawNulls)
+      ? common::FilterKind::kAlwaysTrue
+      : filter->kind();
+  switch (filterKind) {
+    case common::FilterKind::kAlwaysTrue:
+      // Simply add all rows to output.
+      for (vector_size_t i = 0; i < numValues_; i++) {
+        addOutputRow(rows[i]);
+      }
+      break;
+    case common::FilterKind::kIsNull:
+      processNulls(true, rows, rawNulls);
+      break;
+    case common::FilterKind::kIsNotNull:
+      processNulls(false, rows, rawNulls);
+      break;
+    case common::FilterKind::kBigintRange:
+    case common::FilterKind::kBigintValuesUsingHashTable:
+    case common::FilterKind::kBigintValuesUsingBitmask:
+    case common::FilterKind::kNegatedBigintRange:
+    case common::FilterKind::kNegatedBigintValuesUsingHashTable:
+    case common::FilterKind::kNegatedBigintValuesUsingBitmask:
+    case common::FilterKind::kBigintMultiRange: {
+      if constexpr (std::is_same_v<DataT, int64_t>) {
+        processFilter(filter, rows, rawNulls);
+      } else {
+        const auto actualType = CppToType<DataT>::create();
+        VELOX_NYI(
+            "Expected type BIGINT, but found file type {}.",
+            actualType->toString());
+      }
+      break;
+    }
+    case common::FilterKind::kHugeintValuesUsingHashTable:
+    case common::FilterKind::kHugeintRange: {
+      if constexpr (std::is_same_v<DataT, int128_t>) {
+        processFilter(filter, rows, rawNulls);
+      } else {
+        const auto actualType = CppToType<DataT>::create();
+        VELOX_NYI(
+            "Expected type HUGEINT, but found file type {}.",
+            actualType->toString());
+      }
+      break;
+    }
+    default:
+      VELOX_NYI("Unsupported filter: {}.", static_cast<int>(filterKind));
+  }
 }
 
 template <typename DataT>
@@ -119,14 +267,20 @@ void SelectiveDecimalColumnReader<DataT>::read(
     int64_t offset,
     const RowSet& rows,
     const uint64_t* incomingNulls) {
-  VELOX_CHECK(!scanSpec_->filter());
   VELOX_CHECK(!scanSpec_->valueHook());
   prepareRead<int64_t>(offset, rows, incomingNulls);
+  if (!resultNulls_ || !resultNulls_->unique() ||
+      resultNulls_->capacity() * 8 < rows.size()) {
+    // Make sure a dedicated resultNulls_ is allocated with enough capacity as
+    // RleDecoder always assumes it is available.
+    resultNulls_ = AlignedBuffer::allocate<bool>(rows.size(), memoryPool_);
+    rawResultNulls_ = resultNulls_->asMutable<uint64_t>();
+  }
   bool isDense = rows.back() == rows.size() - 1;
   if (isDense) {
-    readHelper<true>(rows);
+    readHelper<true>(scanSpec_->filter(), rows);
   } else {
-    readHelper<false>(rows);
+    readHelper<false>(scanSpec_->filter(), rows);
   }
 }
 
@@ -134,16 +288,18 @@ template <typename DataT>
 void SelectiveDecimalColumnReader<DataT>::getValues(
     const RowSet& rows,
     VectorPtr* result) {
+  rawValues_ = values_->asMutable<char>();
+  getIntValues(rows, requestedType_, result);
+}
+
+template <typename DataT>
+void SelectiveDecimalColumnReader<DataT>::fillDecimals() {
   auto nullsPtr =
       resultNulls() ? resultNulls()->template as<uint64_t>() : nullptr;
   auto scales = scaleBuffer_->as<int64_t>();
   auto values = values_->asMutable<DataT>();
-
   DecimalUtil::fillDecimals<DataT>(
       values, nullsPtr, values, scales, numValues_, scale_);
-
-  rawValues_ = values_->asMutable<char>();
-  getIntValues(rows, requestedType_, result);
 }
 
 template class SelectiveDecimalColumnReader<int64_t>;

--- a/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveDecimalColumnReader.h
@@ -49,7 +49,24 @@ class SelectiveDecimalColumnReader : public SelectiveColumnReader {
 
  private:
   template <bool kDense>
-  void readHelper(RowSet rows);
+  void readHelper(const common::Filter* filter, RowSet rows);
+
+  // Process IsNull and IsNotNull filters.
+  void processNulls(bool isNull, const RowSet& rows, const uint64_t* rawNulls);
+
+  // Process filters on decimal values.
+  void processFilter(
+      const common::Filter* filter,
+      const RowSet& rows,
+      const uint64_t* rawNulls);
+
+  // Dispatch to the respective filter processing based on the filter type.
+  void process(
+      const common::Filter* filter,
+      const RowSet& rows,
+      const uint64_t* rawNulls);
+
+  void fillDecimals();
 
   std::unique_ptr<IntDecoder<true>> valueDecoder_;
   std::unique_ptr<IntDecoder<true>> scaleDecoder_;

--- a/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveFlatMapColumnReader.cpp
@@ -177,6 +177,7 @@ class SelectiveFlatMapAsStructReader : public SelectiveStructColumnReaderBase {
       DwrfParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,
@@ -215,6 +216,7 @@ class SelectiveFlatMapReader : public SelectiveStructColumnReaderBase {
       DwrfParams& params,
       common::ScanSpec& scanSpec)
       : SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.cpp
@@ -31,6 +31,7 @@ SelectiveStructColumnReader::SelectiveStructColumnReader(
     common::ScanSpec& scanSpec,
     bool isRoot)
     : SelectiveStructColumnReaderBase(
+          columnReaderOptions,
           requestedType,
           fileType,
           params,

--- a/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
+++ b/velox/dwio/dwrf/reader/SelectiveStructColumnReader.h
@@ -25,12 +25,14 @@ class SelectiveStructColumnReaderBase
     : public dwio::common::SelectiveStructColumnReaderBase {
  public:
   SelectiveStructColumnReaderBase(
+      const dwio::common::ColumnReaderOptions& columnReaderOptions,
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       DwrfParams& params,
       common::ScanSpec& scanSpec,
       bool isRoot = false)
       : dwio::common::SelectiveStructColumnReaderBase(
+            columnReaderOptions,
             requestedType,
             fileType,
             params,

--- a/velox/dwio/dwrf/writer/ColumnWriter.cpp
+++ b/velox/dwio/dwrf/writer/ColumnWriter.cpp
@@ -2183,7 +2183,12 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
           context, type, sequence, onRecordPosition);
       ret->children_.reserve(type.size());
       for (int32_t i = 0; i < type.size(); ++i) {
-        ret->children_.push_back(create(context, *type.childAt(i), sequence));
+        ret->children_.push_back(create(
+            context,
+            *type.childAt(i),
+            sequence,
+            /*onRecordPosition=*/nullptr,
+            format));
       }
       return ret;
     }
@@ -2199,15 +2204,30 @@ std::unique_ptr<BaseColumnWriter> BaseColumnWriter::create(
       }
       auto ret = std::make_unique<MapColumnWriter>(
           context, type, sequence, onRecordPosition);
-      ret->children_.push_back(create(context, *type.childAt(0), sequence));
-      ret->children_.push_back(create(context, *type.childAt(1), sequence));
+      ret->children_.push_back(create(
+          context,
+          *type.childAt(0),
+          sequence,
+          /*onRecordPosition=*/nullptr,
+          format));
+      ret->children_.push_back(create(
+          context,
+          *type.childAt(1),
+          sequence,
+          /*onRecordPosition=*/nullptr,
+          format));
       return ret;
     }
     case TypeKind::ARRAY: {
       VELOX_CHECK_EQ(type.size(), 1, "Array should have exactly one child");
       auto ret = std::make_unique<ListColumnWriter>(
           context, type, sequence, onRecordPosition);
-      ret->children_.push_back(create(context, *type.childAt(0), sequence));
+      ret->children_.push_back(create(
+          context,
+          *type.childAt(0),
+          sequence,
+          /*onRecordPosition=*/nullptr,
+          format));
       return ret;
     }
     default:

--- a/velox/dwio/dwrf/writer/Writer.cpp
+++ b/velox/dwio/dwrf/writer/Writer.cpp
@@ -200,7 +200,12 @@ Writer::Writer(
   }
 
   if (options.columnWriterFactory == nullptr) {
-    writer_ = BaseColumnWriter::create(writerBase_->getContext(), *schema_);
+    writer_ = BaseColumnWriter::create(
+        writerBase_->getContext(),
+        *schema_,
+        /*sequence=*/0,
+        /*onRecordPosition=*/nullptr,
+        options.format);
   } else {
     writer_ = options.columnWriterFactory(writerBase_->getContext(), *schema_);
   }

--- a/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
+++ b/velox/dwio/parquet/reader/DeltaByteArrayDecoder.h
@@ -21,6 +21,40 @@
 
 namespace facebook::velox::parquet {
 
+namespace {
+
+// improved from Apache Arrow:
+// https://github.com/apache/arrow/blob/maint-20.0.0/cpp/src/arrow/util/decimal.cc#L1144
+template <typename T>
+FOLLY_ALWAYS_INLINE T fromBigEndian(std::string_view&& str) {
+  VELOX_CHECK_LE(
+      str.size(),
+      sizeof(T),
+      "Length of byte array passed to fromBigEndian is too large");
+
+  const uint8_t* bytes = reinterpret_cast<const uint8_t*>(str.data());
+  const size_t len = str.size();
+  if (!len) {
+    return {};
+  }
+
+  const bool is_negative = static_cast<int8_t>(bytes[0]) < 0;
+
+  T result = -1 * is_negative;
+  memcpy(reinterpret_cast<uint8_t*>(&result) + sizeof(T) - len, bytes, len);
+
+  if constexpr (std::is_same_v<T, int128_t>) {
+    return __builtin_bswap128(result);
+  } else if constexpr (std::is_same_v<T, int64_t>) {
+    return __builtin_bswap64(result);
+  } else if constexpr (std::is_same_v<T, int32_t>) {
+    return __builtin_bswap32(result);
+  }
+  VELOX_UNREACHABLE();
+}
+
+} // namespace
+
 // DeltaByteArrayDecoder is adapted from Apache Arrow:
 // https://github.com/apache/arrow/blob/apache-arrow-15.0.0/cpp/src/parquet/encoding.cc#L2758-L2889
 class DeltaLengthByteArrayDecoder {
@@ -108,7 +142,14 @@ class DeltaByteArrayDecoder {
         }
 
         // We are at a non-null value on a row to visit.
-        toSkip = visitor.process(readString(), atEnd);
+        using T = typename Visitor::DataType;
+        if constexpr (
+            std::is_same_v<T, int128_t> || std::is_same_v<T, int64_t> ||
+            std::is_same_v<T, int32_t>) {
+          toSkip = visitor.process(fromBigEndian<T>(readString()), atEnd);
+        } else {
+          toSkip = visitor.process(readString(), atEnd);
+        }
       }
       ++current;
       if (toSkip) {

--- a/velox/dwio/parquet/reader/PageReader.cpp
+++ b/velox/dwio/parquet/reader/PageReader.cpp
@@ -746,7 +746,8 @@ void PageReader::makeDecoder() {
       }
       break;
     case Encoding::DELTA_BYTE_ARRAY:
-      if (parquetType == thrift::Type::BYTE_ARRAY) {
+      if (parquetType == thrift::Type::BYTE_ARRAY ||
+          parquetType == thrift::Type::FIXED_LEN_BYTE_ARRAY) {
         deltaByteArrDecoder_ =
             std::make_unique<DeltaByteArrayDecoder>(pageData_);
         break;

--- a/velox/dwio/parquet/reader/PageReader.h
+++ b/velox/dwio/parquet/reader/PageReader.h
@@ -280,6 +280,18 @@ class PageReader {
       } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
         nullsFromFastPath = false;
         deltaBpDecoder_->readWithVisitor<true>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
+        if constexpr (
+            std::is_same_v<typename Visitor::DataType, int128_t> ||
+            std::is_same_v<typename Visitor::DataType, int64_t> ||
+            std::is_same_v<typename Visitor::DataType, int32_t>) {
+          nullsFromFastPath = false;
+          deltaByteArrDecoder_->readWithVisitor<true>(nulls, visitor);
+        } else {
+          VELOX_UNSUPPORTED(
+              "Encoding not supported for FLBA & !(string || int32/64/128): {}",
+              encoding_);
+        }
       } else {
         directDecoder_->readWithVisitor<true>(
             nulls, visitor, nullsFromFastPath);
@@ -290,6 +302,17 @@ class PageReader {
         dictionaryIdDecoder_->readWithVisitor<false>(nullptr, dictVisitor);
       } else if (encoding_ == thrift::Encoding::DELTA_BINARY_PACKED) {
         deltaBpDecoder_->readWithVisitor<false>(nulls, visitor);
+      } else if (encoding_ == thrift::Encoding::DELTA_BYTE_ARRAY) {
+        if constexpr (
+            std::is_same_v<typename Visitor::DataType, int128_t> ||
+            std::is_same_v<typename Visitor::DataType, int64_t> ||
+            std::is_same_v<typename Visitor::DataType, int32_t>) {
+          deltaByteArrDecoder_->readWithVisitor<false>(nulls, visitor);
+        } else {
+          VELOX_UNSUPPORTED(
+              "Encoding not supported for FLBA & !(string || int32/64/128): {}",
+              encoding_);
+        }
       } else {
         directDecoder_->readWithVisitor<false>(
             nulls, visitor, !this->type_->type()->isShortDecimal());

--- a/velox/dwio/parquet/reader/ParquetColumnReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.cpp
@@ -38,7 +38,8 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
-    common::ScanSpec& scanSpec) {
+    common::ScanSpec& scanSpec,
+    memory::MemoryPool& pool) {
   auto colName = scanSpec.fieldName();
 
   switch (fileType->type()->kind()) {
@@ -59,7 +60,7 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::ROW:
       return std::make_unique<StructColumnReader>(
-          columnReaderOptions, requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec, pool);
 
     case TypeKind::VARBINARY:
     case TypeKind::VARCHAR:
@@ -67,11 +68,11 @@ std::unique_ptr<dwio::common::SelectiveColumnReader> ParquetColumnReader::build(
 
     case TypeKind::ARRAY:
       return std::make_unique<ListColumnReader>(
-          columnReaderOptions, requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec, pool);
 
     case TypeKind::MAP:
       return std::make_unique<MapColumnReader>(
-          columnReaderOptions, requestedType, fileType, params, scanSpec);
+          columnReaderOptions, requestedType, fileType, params, scanSpec, pool);
 
     case TypeKind::BOOLEAN:
       return std::make_unique<BooleanColumnReader>(

--- a/velox/dwio/parquet/reader/ParquetColumnReader.h
+++ b/velox/dwio/parquet/reader/ParquetColumnReader.h
@@ -47,6 +47,7 @@ class ParquetColumnReader {
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      memory::MemoryPool& pool);
 };
 } // namespace facebook::velox::parquet

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -1066,12 +1066,15 @@ class ParquetRowReader::Impl {
         options_.timestampPrecision());
     requestedType_ = options_.requestedType() ? options_.requestedType()
                                               : readerBase_->schema();
+    columnReaderOptions_ =
+        dwio::common::makeColumnReaderOptions(readerBase_->options());
     columnReader_ = ParquetColumnReader::build(
         columnReaderOptions_,
         requestedType_,
         readerBase_->schemaWithId(), // Id is schema id
         params,
-        *options_.scanSpec());
+        *options_.scanSpec(),
+        pool_);
     columnReader_->setIsTopLevel();
 
     filterRowGroups();
@@ -1081,9 +1084,6 @@ class ParquetRowReader::Impl {
       // table scan.
       advanceToNextRowGroup();
     }
-
-    columnReaderOptions_ =
-        dwio::common::makeColumnReaderOptions(readerBase_->options());
   }
 
   void filterRowGroups() {

--- a/velox/dwio/parquet/reader/ParquetReader.cpp
+++ b/velox/dwio/parquet/reader/ParquetReader.cpp
@@ -722,6 +722,7 @@ TypePtr ReaderBase::convertType(
 
   static std::string_view kTypeMappingErrorFmtStr =
       "Converted type {} is not allowed for requested type {}";
+  const bool enableRequestedTypeCheck = options_.enableRequestedTypeCheck();
   if (schemaElement.__isset.converted_type) {
     switch (schemaElement.converted_type) {
       case thrift::ConvertedType::INT_8:
@@ -731,14 +732,16 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TINYINT ||
-                requestedType->kind() == TypeKind::SMALLINT ||
-                requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "TINYINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::TINYINT ||
+                  requestedType->kind() == TypeKind::SMALLINT ||
+                  requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "TINYINT",
+              requestedType->toString());
+        }
         return TINYINT();
 
       case thrift::ConvertedType::INT_16:
@@ -748,13 +751,15 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::SMALLINT ||
-                requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "SMALLINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::SMALLINT ||
+                  requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "SMALLINT",
+              requestedType->toString());
+        }
         return SMALLINT();
 
       case thrift::ConvertedType::INT_32:
@@ -764,12 +769,14 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT32,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "INTEGER",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "INTEGER",
+              requestedType->toString());
+        }
         return INTEGER();
 
       case thrift::ConvertedType::INT_64:
@@ -779,11 +786,13 @@ TypePtr ReaderBase::convertType(
             thrift::Type::INT64,
             "{} converted type can only be set for value of thrift::Type::INT32",
             schemaElement.converted_type);
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "BIGINT",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "BIGINT",
+              requestedType->toString());
+        }
         return BIGINT();
 
       case thrift::ConvertedType::DATE:
@@ -791,11 +800,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT32,
             "DATE converted type can only be set for value of thrift::Type::INT32");
-        VELOX_CHECK(
-            !requestedType || requestedType->isDate(),
-            kTypeMappingErrorFmtStr,
-            "DATE",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->isDate(),
+              kTypeMappingErrorFmtStr,
+              "DATE",
+              requestedType->toString());
+        }
         return DATE();
 
       case thrift::ConvertedType::TIMESTAMP_MICROS:
@@ -804,11 +815,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::INT64,
             "TIMESTAMP_MICROS or TIMESTAMP_MILLIS converted type can only be set for value of thrift::Type::INT64");
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
-            kTypeMappingErrorFmtStr,
-            "TIMESTAMP",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
+              kTypeMappingErrorFmtStr,
+              "TIMESTAMP",
+              requestedType->toString());
+        }
         return TIMESTAMP();
 
       case thrift::ConvertedType::DECIMAL: {
@@ -817,20 +830,20 @@ TypePtr ReaderBase::convertType(
             "DECIMAL requires a length and scale specifier!");
         const auto schemaElementPrecision = schemaElement.precision;
         const auto schemaElementScale = schemaElement.scale;
-        // A long decimal requested type cannot read a value of a short decimal.
-        // As a result, the mapping from short to long decimal is currently
-        // restricted.
+        // A long decimal requested type cannot read a value of a short
+        // decimal. As a result, the mapping from short to long decimal is
+        // currently restricted.
         auto type = DECIMAL(schemaElementPrecision, schemaElementScale);
-        if (requestedType) {
+        if (enableRequestedTypeCheck && requestedType) {
           VELOX_CHECK(
               requestedType->isDecimal(),
               kTypeMappingErrorFmtStr,
               "DECIMAL",
               requestedType->toString());
-          // Reading short decimals with a long decimal requested type is not
-          // yet possible. To allow for correct interpretation of the values,
-          // the scale of the file type and requested type must match while
-          // precision may be larger.
+          // Reading short decimals with a long decimal requested type is
+          // not yet possible. To allow for correct interpretation of the
+          // values, the scale of the file type and requested type must
+          // match while precision may be larger.
           if (requestedType->isShortDecimal()) {
             const auto& shortDecimalType = requestedType->asShortDecimal();
             VELOX_CHECK(
@@ -858,11 +871,13 @@ TypePtr ReaderBase::convertType(
         switch (schemaElement.type) {
           case thrift::Type::BYTE_ARRAY:
           case thrift::Type::FIXED_LEN_BYTE_ARRAY:
-            VELOX_CHECK(
-                !requestedType || requestedType->kind() == TypeKind::VARCHAR,
-                kTypeMappingErrorFmtStr,
-                "VARCHAR",
-                requestedType->toString());
+            if (enableRequestedTypeCheck) {
+              VELOX_CHECK(
+                  !requestedType || requestedType->kind() == TypeKind::VARCHAR,
+                  kTypeMappingErrorFmtStr,
+                  "VARCHAR",
+                  requestedType->toString());
+            }
             return VARCHAR();
           default:
             VELOX_FAIL(
@@ -873,11 +888,13 @@ TypePtr ReaderBase::convertType(
             schemaElement.type,
             thrift::Type::BYTE_ARRAY,
             "ENUM converted type can only be set for value of thrift::Type::BYTE_ARRAY");
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::VARCHAR,
-            kTypeMappingErrorFmtStr,
-            "VARCHAR",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::VARCHAR,
+              kTypeMappingErrorFmtStr,
+              "VARCHAR",
+              requestedType->toString());
+        }
         return VARCHAR();
       }
       case thrift::ConvertedType::MAP:
@@ -896,69 +913,85 @@ TypePtr ReaderBase::convertType(
   } else {
     switch (schemaElement.type) {
       case thrift::Type::type::BOOLEAN:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BOOLEAN,
-            kTypeMappingErrorFmtStr,
-            "BOOLEAN",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BOOLEAN,
+              kTypeMappingErrorFmtStr,
+              "BOOLEAN",
+              requestedType->toString());
+        }
         return BOOLEAN();
       case thrift::Type::type::INT32:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::INTEGER ||
-                requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "INTEGER",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::INTEGER ||
+                  requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "INTEGER",
+              requestedType->toString());
+        }
         return INTEGER();
       case thrift::Type::type::INT64:
         // For Int64 Timestamp in nano precision
         if (schemaElement.__isset.logicalType &&
             schemaElement.logicalType.__isset.TIMESTAMP) {
+          if (enableRequestedTypeCheck) {
+            VELOX_CHECK(
+                !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
+                kTypeMappingErrorFmtStr,
+                "TIMESTAMP",
+                requestedType->toString());
+          }
+          return TIMESTAMP();
+        }
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::BIGINT,
+              kTypeMappingErrorFmtStr,
+              "BIGINT",
+              requestedType->toString());
+        }
+        return BIGINT();
+      case thrift::Type::type::INT96:
+        if (enableRequestedTypeCheck) {
           VELOX_CHECK(
               !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
               kTypeMappingErrorFmtStr,
               "TIMESTAMP",
               requestedType->toString());
-          return TIMESTAMP();
         }
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::BIGINT,
-            kTypeMappingErrorFmtStr,
-            "BIGINT",
-            requestedType->toString());
-        return BIGINT();
-      case thrift::Type::type::INT96:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::TIMESTAMP,
-            kTypeMappingErrorFmtStr,
-            "TIMESTAMP",
-            requestedType->toString());
         return TIMESTAMP(); // INT96 only maps to a timestamp
       case thrift::Type::type::FLOAT:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::REAL ||
-                requestedType->kind() == TypeKind::DOUBLE,
-            kTypeMappingErrorFmtStr,
-            "REAL",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::REAL ||
+                  requestedType->kind() == TypeKind::DOUBLE,
+              kTypeMappingErrorFmtStr,
+              "REAL",
+              requestedType->toString());
+        }
         return REAL();
       case thrift::Type::type::DOUBLE:
-        VELOX_CHECK(
-            !requestedType || requestedType->kind() == TypeKind::DOUBLE,
-            kTypeMappingErrorFmtStr,
-            "DOUBLE",
-            requestedType->toString());
+        if (enableRequestedTypeCheck) {
+          VELOX_CHECK(
+              !requestedType || requestedType->kind() == TypeKind::DOUBLE,
+              kTypeMappingErrorFmtStr,
+              "DOUBLE",
+              requestedType->toString());
+        }
         return DOUBLE();
       case thrift::Type::type::BYTE_ARRAY:
       case thrift::Type::type::FIXED_LEN_BYTE_ARRAY:
         if (requestedType && requestedType->isVarchar()) {
           return VARCHAR();
         } else {
-          VELOX_CHECK(
-              !requestedType || requestedType->isVarbinary(),
-              kTypeMappingErrorFmtStr,
-              "VARBINARY",
-              requestedType->toString());
+          if (enableRequestedTypeCheck) {
+            VELOX_CHECK(
+                !requestedType || requestedType->isVarbinary(),
+                kTypeMappingErrorFmtStr,
+                "VARBINARY",
+                requestedType->toString());
+          }
           return VARBINARY();
         }
 

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.cpp
@@ -33,6 +33,9 @@ PageReader* readLeafRepDefs(
       return nullptr;
     }
     auto pageReader = reader->formatData().as<ParquetData>().reader();
+    if (pageReader == nullptr) {
+      return nullptr;
+    }
     pageReader->decodeRepDefs(numTop);
     return pageReader;
   }
@@ -114,7 +117,8 @@ MapColumnReader::MapColumnReader(
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
-    common::ScanSpec& scanSpec)
+    common::ScanSpec& scanSpec,
+    memory::MemoryPool& pool)
     : dwio::common::SelectiveMapColumnReader(
           requestedType,
           fileType,
@@ -128,13 +132,15 @@ MapColumnReader::MapColumnReader(
       keyChildType,
       fileType_->childAt(0),
       params,
-      *scanSpec.children()[0]);
+      *scanSpec.children()[0],
+      pool);
   elementReader_ = ParquetColumnReader::build(
       columnReaderOptions,
       elementChildType,
       fileType_->childAt(1),
       params,
-      *scanSpec.children()[1]);
+      *scanSpec.children()[1],
+      pool);
   reinterpret_cast<const ParquetTypeWithId*>(fileType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {keyReader_.get(), elementReader_.get()};
@@ -232,7 +238,8 @@ ListColumnReader::ListColumnReader(
     const TypePtr& requestedType,
     const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
     ParquetParams& params,
-    common::ScanSpec& scanSpec)
+    common::ScanSpec& scanSpec,
+    memory::MemoryPool& pool)
     : dwio::common::SelectiveListColumnReader(
           requestedType,
           fileType,
@@ -244,7 +251,8 @@ ListColumnReader::ListColumnReader(
       childType,
       fileType_->childAt(0),
       params,
-      *scanSpec.children()[0]);
+      *scanSpec.children()[0],
+      pool);
   reinterpret_cast<const ParquetTypeWithId*>(fileType.get())
       ->makeLevelInfo(levelInfo_);
   children_ = {child_.get()};

--- a/velox/dwio/parquet/reader/RepeatedColumnReader.h
+++ b/velox/dwio/parquet/reader/RepeatedColumnReader.h
@@ -61,7 +61,8 @@ class MapColumnReader : public dwio::common::SelectiveMapColumnReader {
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      memory::MemoryPool& pool);
 
   void prepareRead(
       vector_size_t offset,
@@ -118,7 +119,8 @@ class ListColumnReader : public dwio::common::SelectiveListColumnReader {
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      memory::MemoryPool& pool);
 
   void prepareRead(
       vector_size_t offset,

--- a/velox/dwio/parquet/reader/StructColumnReader.h
+++ b/velox/dwio/parquet/reader/StructColumnReader.h
@@ -37,7 +37,8 @@ class StructColumnReader : public dwio::common::SelectiveStructColumnReader {
       const TypePtr& requestedType,
       const std::shared_ptr<const dwio::common::TypeWithId>& fileType,
       ParquetParams& params,
-      common::ScanSpec& scanSpec);
+      common::ScanSpec& scanSpec,
+      memory::MemoryPool& pool);
 
   void read(int64_t offset, const RowSet& rows, const uint64_t* incomingNulls)
       override;

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -297,6 +297,11 @@ class ParquetTableScanTest : public HiveConnectorTestBase {
         "SELECT t from tmp where t != TIMESTAMP '2000-09-12 22:36:29'");
   }
 
+  const std::vector<std::shared_ptr<connector::ConnectorSplit>>& splits()
+      const {
+    return splits_;
+  }
+
  private:
   RowTypePtr getRowType(std::vector<std::string>&& outputColumnNames) const {
     std::vector<TypePtr> types;
@@ -1175,6 +1180,133 @@ TEST_F(ParquetTableScanTest, schemaMatch) {
   assertEqualVectors(rows->childAt(0), dataFileVectors->childAt(0));
   assertEqualVectors(rows->childAt(1), dataFileVectors->childAt(1));
   assertEqualVectors(rows->childAt(2), nullVector);
+}
+
+TEST_F(ParquetTableScanTest, structMatchByName) {
+  const auto assertSelectUseColumnNames =
+      [this](
+          const RowTypePtr& outputType,
+          const std::string& sql,
+          const std::string& remainingFilter = "") {
+        const auto plan =
+            PlanBuilder().tableScan(outputType, {}, remainingFilter).planNode();
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .connectorSessionProperty(
+                kHiveConnectorId,
+                HiveConfig::kParquetUseColumnNamesSession,
+                "true")
+            .splits(splits())
+            .assertResults(sql);
+      };
+
+  std::vector<int64_t> values = {2};
+  const auto id = makeFlatVector<int64_t>(values);
+  const auto name = makeRowVector(
+      {"first", "last"},
+      {
+          makeFlatVector<std::string>({"Janet"}),
+          makeFlatVector<std::string>({"Jones"}),
+      });
+  const auto address = makeFlatVector<std::string>({"567 Maple Drive"});
+  auto vector = makeRowVector({"id", "name", "address"}, {id, name, address});
+
+  WriterOptions options;
+  auto file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {vector}, options);
+
+  loadData(file->getPath(), asRowType(vector->type()), vector);
+  assertSelect({"id", "name", "address"}, "SELECT id, name, address from tmp");
+
+  // Add one non-existing subfield 'middle' to the 'name' field and rename filed
+  // 'address'.
+  auto rowType =
+      ROW({"id", "name", "email"},
+          {BIGINT(),
+           ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
+           VARCHAR()});
+  loadData(file->getPath(), rowType, vector);
+  assertSelectUseColumnNames(
+      rowType, "SELECT 2, ('Janet', null, 'Jones'), null");
+
+  // Filter pushdown on the non-existing field.
+  assertSelectUseColumnNames(
+      rowType, "SELECT * from tmp where false", "not(is_null(name.middle))");
+
+  // Rename subfields of the 'name' field.
+  rowType =
+      ROW({"id", "name", "address"},
+          {BIGINT(), ROW({"a", "b"}, {VARCHAR(), VARCHAR()}), VARCHAR()});
+  loadData(file->getPath(), rowType, vector);
+  assertSelectUseColumnNames(rowType, "SELECT 2, null, '567 Maple Drive'");
+
+  // Filter pushdown on the NULL subfield.
+  assertSelectUseColumnNames(
+      rowType, "SELECT * from tmp where false", "not(is_null(name))");
+
+  // Deletion of one subfield from the 'name' field.
+  rowType =
+      ROW({"id", "name", "address"},
+          {BIGINT(), ROW({"full"}, {VARCHAR()}), VARCHAR()});
+  loadData(file->getPath(), rowType, vector);
+  assertSelectUseColumnNames(rowType, "SELECT 2, row(null), '567 Maple Drive'");
+
+  // Filter pushdown on the non-existing subfield.
+  assertSelectUseColumnNames(
+      rowType, "SELECT * from tmp where false", "not(is_null(name.full))");
+
+  // No subfield in the 'name' field.
+  rowType = ROW({"id", "name", "address"}, {BIGINT(), ROW({}, {}), VARCHAR()});
+  const auto op = PlanBuilder()
+                      .startTableScan()
+                      .outputType(rowType)
+                      .dataColumns(rowType)
+                      .endTableScan()
+                      .planNode();
+  const auto split = makeSplit(file->getPath());
+  const auto result = AssertQueryBuilder(op)
+                          .connectorSessionProperty(
+                              kHiveConnectorId,
+                              HiveConfig::kParquetUseColumnNamesSession,
+                              "true")
+                          .split(split)
+                          .copyResults(pool());
+  const auto rows = result->as<RowVector>();
+  const auto expected = makeRowVector(ROW({}, {}), 1);
+  assertEqualVectors(expected, rows->childAt(1));
+
+  // Case sensitivity when matching by name.
+  vector = makeRowVector(
+      {"id", "name", "address"},
+      {id,
+       makeRowVector(
+           {"FIRST", "LAST"},
+           {
+               makeFlatVector<std::string>({"Janet"}),
+               makeFlatVector<std::string>({"Jones"}),
+           }),
+       address});
+  file = TempFilePath::create();
+  writeToParquetFile(file->getPath(), {vector}, options);
+
+  rowType =
+      ROW({"id", "name", "address"},
+          {BIGINT(),
+           ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
+           VARCHAR()});
+  loadData(file->getPath(), rowType, vector);
+  assertSelectUseColumnNames(rowType, "SELECT 2, null, '567 Maple Drive'");
+
+  // Case insensitivity when matching by name and reading as lower case.
+  auto plan = PlanBuilder().tableScan(rowType, {}, "", rowType).planNode();
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kHiveConnectorId, HiveConfig::kParquetUseColumnNamesSession, "true")
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          HiveConfig::kFileColumnNamesReadAsLowerCaseSession,
+          "true")
+      .splits(splits())
+      .assertResults("SELECT 2, ('Janet', null, 'Jones'), '567 Maple Drive'");
 }
 
 TEST_F(ParquetTableScanTest, deltaByteArray) {

--- a/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
+++ b/velox/dwio/parquet/tests/reader/ParquetTableScanTest.cpp
@@ -546,6 +546,23 @@ TEST_F(ParquetTableScanTest, array) {
 
   assertSelectWithFilter(
       {"repeatedInt"}, {}, "", "SELECT UNNEST(array[array[1,2,3]])");
+
+  // Requested type does not match the element type.
+  auto rowType = ROW({"repeatedInt"}, {ARRAY(INTEGER())});
+  parse::ParseOptions options;
+
+  auto plan = PlanBuilder(pool_.get())
+                  .setParseOptions(options)
+                  .tableScan(rowType, {}, "", rowType, {})
+                  .planNode();
+
+  AssertQueryBuilder(plan, duckDbQueryRunner_)
+      .connectorSessionProperty(
+          kHiveConnectorId,
+          HiveConfig::kEnableRequestedTypeCheckSession,
+          "false")
+      .splits({makeSplit(getExampleFilePath("old_repeated_int.parquet"))})
+      .assertResults("SELECT UNNEST(array[array[1,2,3]])");
 }
 
 // Optional array with required elements.

--- a/velox/exec/MergeJoin.cpp
+++ b/velox/exec/MergeJoin.cpp
@@ -113,9 +113,10 @@ void MergeJoin::initialize() {
         isSemiFilterJoin(joinType_)) {
       joinTracker_ = JoinTracker(outputBatchSize_, pool());
     }
-  } else if (joinNode_->isAntiJoin()) {
+  } else if (joinNode_->isAntiJoin() || joinNode_->isFullJoin()) {
     // Anti join needs to track the left side rows that have no match on the
-    // right.
+    // right. Full outer join needs to track the right side rows that have no
+    // match on the left.
     joinTracker_ = JoinTracker(outputBatchSize_, pool());
   }
 
@@ -392,7 +393,8 @@ bool MergeJoin::tryAddOutputRow(
     const RowVectorPtr& leftBatch,
     vector_size_t leftRow,
     const RowVectorPtr& rightBatch,
-    vector_size_t rightRow) {
+    vector_size_t rightRow,
+    bool isRightJoinForFullOuter) {
   if (outputSize_ == outputBatchSize_) {
     return false;
   }
@@ -426,12 +428,15 @@ bool MergeJoin::tryAddOutputRow(
         filterRightInputProjections_);
 
     if (joinTracker_) {
-      if (isRightJoin(joinType_) || isRightSemiFilterJoin(joinType_)) {
+      if (isRightJoin(joinType_) || isRightSemiFilterJoin(joinType_) ||
+          (isFullJoin(joinType_) && isRightJoinForFullOuter)) {
         // Record right-side row with a match on the left-side.
-        joinTracker_->addMatch(rightBatch, rightRow, outputSize_);
+        joinTracker_->addMatch(
+            rightBatch, rightRow, outputSize_, isRightJoinForFullOuter);
       } else {
         // Record left-side row with a match on the right-side.
-        joinTracker_->addMatch(leftBatch, leftRow, outputSize_);
+        joinTracker_->addMatch(
+            leftBatch, leftRow, outputSize_, isRightJoinForFullOuter);
       }
     }
   }
@@ -441,7 +446,8 @@ bool MergeJoin::tryAddOutputRow(
   if (isAntiJoin(joinType_)) {
     VELOX_CHECK(joinTracker_.has_value());
     // Record left-side row with a match on the right-side.
-    joinTracker_->addMatch(leftBatch, leftRow, outputSize_);
+    joinTracker_->addMatch(
+        leftBatch, leftRow, outputSize_, isRightJoinForFullOuter);
   }
 
   ++outputSize_;
@@ -460,14 +466,15 @@ bool MergeJoin::prepareOutput(
       return true;
     }
 
-    if (isRightJoin(joinType_) && right != currentRight_) {
-      return true;
-    }
-
     // If there is a new right, we need to flatten the dictionary.
     if (!isRightFlattened_ && right && currentRight_ != right) {
       flattenRightProjections();
     }
+
+    if (right != currentRight_) {
+      return true;
+    }
+
     return false;
   }
 
@@ -490,11 +497,10 @@ bool MergeJoin::prepareOutput(
     }
   } else {
     for (const auto& projection : leftProjections_) {
+      auto column = left->childAt(projection.inputChannel);
+      column->clearContainingLazyAndWrapped();
       localColumns[projection.outputChannel] = BaseVector::wrapInDictionary(
-          {},
-          leftOutputIndices_,
-          outputBatchSize_,
-          left->childAt(projection.inputChannel));
+          {}, leftOutputIndices_, outputBatchSize_, column);
     }
   }
   currentLeft_ = left;
@@ -510,11 +516,10 @@ bool MergeJoin::prepareOutput(
     isRightFlattened_ = true;
   } else {
     for (const auto& projection : rightProjections_) {
+      auto column = right->childAt(projection.inputChannel);
+      column->clearContainingLazyAndWrapped();
       localColumns[projection.outputChannel] = BaseVector::wrapInDictionary(
-          {},
-          rightOutputIndices_,
-          outputBatchSize_,
-          right->childAt(projection.inputChannel));
+          {}, rightOutputIndices_, outputBatchSize_, column);
     }
     isRightFlattened_ = false;
   }
@@ -579,6 +584,39 @@ bool MergeJoin::prepareOutput(
 bool MergeJoin::addToOutput() {
   if (isRightJoin(joinType_) || isRightSemiFilterJoin(joinType_)) {
     return addToOutputForRightJoin();
+  } else if (isFullJoin(joinType_) && filter_) {
+    if (!leftForRightJoinMatch_) {
+      leftForRightJoinMatch_ = leftMatch_;
+      rightForRightJoinMatch_ = rightMatch_;
+    }
+
+    if (leftMatch_ && rightMatch_ && !leftJoinForFullFinished_) {
+      auto left = addToOutputForLeftJoin();
+      if (!leftMatch_) {
+        leftJoinForFullFinished_ = true;
+      }
+      if (left) {
+        if (!leftMatch_) {
+          leftMatch_ = leftForRightJoinMatch_;
+          rightMatch_ = rightForRightJoinMatch_;
+        }
+
+        return true;
+      }
+    }
+
+    if (!leftMatch_ && !rightJoinForFullFinished_) {
+      leftMatch_ = leftForRightJoinMatch_;
+      rightMatch_ = rightForRightJoinMatch_;
+      rightJoinForFullFinished_ = true;
+    }
+
+    auto right = addToOutputForRightJoin();
+
+    leftForRightJoinMatch_ = leftMatch_;
+    rightForRightJoinMatch_ = rightMatch_;
+
+    return right;
   } else {
     return addToOutputForLeftJoin();
   }
@@ -727,7 +765,9 @@ bool MergeJoin::addToOutputForRightJoin() {
         }
 
         for (auto j = leftStartRow; j < leftEndRow; ++j) {
-          if (!tryAddOutputRow(leftBatch, j, rightBatch, i)) {
+          const auto isRightJoinForFullOuter = isFullJoin(joinType_);
+          if (!tryAddOutputRow(
+                  leftBatch, j, rightBatch, i, isRightJoinForFullOuter)) {
             // If we run out of space in the current output_, we will need to
             // produce a buffer and continue processing left later. In this
             // case, we cannot leave left as a lazy vector, since we cannot have
@@ -1141,7 +1181,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
           isFullJoin(joinType_)) {
         // If output_ is currently wrapping a different buffer, return it
         // first.
-        if (prepareOutput(input_, nullptr)) {
+        if (prepareOutput(input_, rightInput_)) {
           output_->resize(outputSize_);
           return std::move(output_);
         }
@@ -1166,7 +1206,7 @@ RowVectorPtr MergeJoin::doGetOutput() {
       if (isRightJoin(joinType_) || isFullJoin(joinType_)) {
         // If output_ is currently wrapping a different buffer, return it
         // first.
-        if (prepareOutput(nullptr, rightInput_)) {
+        if (prepareOutput(input_, rightInput_)) {
           output_->resize(outputSize_);
           return std::move(output_);
         }
@@ -1218,6 +1258,8 @@ RowVectorPtr MergeJoin::doGetOutput() {
           endRightRow < rightInput_->size(),
           std::nullopt};
 
+      leftJoinForFullFinished_ = false;
+      rightJoinForFullFinished_ = false;
       if (!leftMatch_->complete || !rightMatch_->complete) {
         if (!leftMatch_->complete) {
           // Need to continue looking for the end of match.
@@ -1262,8 +1304,6 @@ RowVectorPtr MergeJoin::doGetOutput() {
 RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
   const auto numRows = output->size();
 
-  RowVectorPtr fullOuterOutput = nullptr;
-
   BufferPtr indices = allocateIndices(numRows, pool());
   auto* rawIndices = indices->asMutable<vector_size_t>();
   vector_size_t numPassed = 0;
@@ -1280,84 +1320,41 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
     // If all matches for a given left-side row fail the filter, add a row to
     // the output with nulls for the right-side columns.
-    const auto onMiss = [&](auto row) {
+    const auto onMiss = [&](auto row, bool isRightJoinForFullOuter) {
       if (isSemiFilterJoin(joinType_)) {
         return;
       }
       rawIndices[numPassed++] = row;
 
-      if (isFullJoin(joinType_)) {
-        // For filtered rows, it is necessary to insert additional data
-        // to ensure the result set is complete. Specifically, we
-        // need to generate two records: one record containing the
-        // columns from the left table along with nulls for the
-        // right table, and another record containing the columns
-        // from the right table along with nulls for the left table.
-        // For instance, the current output is filtered based on the condition
-        // t > 1.
-
-        // 1, 1
-        // 2, 2
-        // 3, 3
-
-        // In this scenario, we need to additionally insert a record 1, 1.
-        // Subsequently, we will set the values of the columns on the left to
-        // null and the values of the columns on the right to null as well. By
-        // doing so, we will obtain the final result set.
-
-        // 1,   null
-        // null,  1
-        // 2, 2
-        // 3, 3
-        fullOuterOutput = BaseVector::create<RowVector>(
-            output->type(), output->size() + 1, pool());
-
-        for (auto i = 0; i < row + 1; ++i) {
-          for (auto j = 0; j < output->type()->size(); ++j) {
-            fullOuterOutput->childAt(j)->copy(
-                output->childAt(j).get(), i, i, 1);
+      if (!isRightJoin(joinType_)) {
+        if (isFullJoin(joinType_) && isRightJoinForFullOuter) {
+          for (auto& projection : leftProjections_) {
+            auto target = output->childAt(projection.outputChannel);
+            target->setNull(row, true);
           }
-        }
-
-        for (auto j = 0; j < output->type()->size(); ++j) {
-          fullOuterOutput->childAt(j)->copy(
-              output->childAt(j).get(), row + 1, row, 1);
-        }
-
-        for (auto i = row + 1; i < output->size(); ++i) {
-          for (auto j = 0; j < output->type()->size(); ++j) {
-            fullOuterOutput->childAt(j)->copy(
-                output->childAt(j).get(), i + 1, i, 1);
+        } else {
+          for (auto& projection : rightProjections_) {
+            auto target = output->childAt(projection.outputChannel);
+            target->setNull(row, true);
           }
-        }
-
-        for (auto& projection : leftProjections_) {
-          auto& target = fullOuterOutput->childAt(projection.outputChannel);
-          target->setNull(row, true);
-        }
-
-        for (auto& projection : rightProjections_) {
-          auto& target = fullOuterOutput->childAt(projection.outputChannel);
-          target->setNull(row + 1, true);
-        }
-      } else if (!isRightJoin(joinType_)) {
-        for (auto& projection : rightProjections_) {
-          auto& target = output->childAt(projection.outputChannel);
-          target->setNull(row, true);
         }
       } else {
         for (auto& projection : leftProjections_) {
-          auto& target = output->childAt(projection.outputChannel);
+          auto target = output->childAt(projection.outputChannel);
           target->setNull(row, true);
         }
       }
     };
 
     auto onMatch = [&](auto row, bool firstMatch) {
-      const bool isNonSemiAntiJoin =
-          !isSemiFilterJoin(joinType_) && !isAntiJoin(joinType_);
+      const bool isFullLeftJoin =
+          isFullJoin(joinType_) && !joinTracker_->isRightJoinForFullOuter(row);
 
-      if ((isSemiFilterJoin(joinType_) && firstMatch) || isNonSemiAntiJoin) {
+      const bool isNonSemiAntiFullJoin = !isSemiFilterJoin(joinType_) &&
+          !isAntiJoin(joinType_) && !isFullJoin(joinType_);
+
+      if ((isSemiFilterJoin(joinType_) && firstMatch) ||
+          isNonSemiAntiFullJoin || isFullLeftJoin) {
         rawIndices[numPassed++] = row;
       }
     };
@@ -1418,17 +1415,10 @@ RowVectorPtr MergeJoin::applyFilter(const RowVectorPtr& output) {
 
   if (numPassed == numRows) {
     // All rows passed.
-    if (fullOuterOutput) {
-      return fullOuterOutput;
-    }
     return output;
   }
 
   // Some, but not all rows passed.
-  if (fullOuterOutput) {
-    return wrap(numPassed, indices, fullOuterOutput);
-  }
-
   return wrap(numPassed, indices, output);
 }
 

--- a/velox/exec/tests/TableScanTest.cpp
+++ b/velox/exec/tests/TableScanTest.cpp
@@ -1190,6 +1190,92 @@ TEST_F(TableScanTest, missingColumnsInRepeatedColumns) {
       .assertResults(expected);
 }
 
+TEST_F(TableScanTest, structMatchByName) {
+  const auto assertSelectUseColumnNames =
+      [this](
+          const RowTypePtr& outputType,
+          const std::string& sql,
+          const std::string& filePath,
+          const std::string& remainingFilter = "") {
+        const auto plan =
+            PlanBuilder().tableScan(outputType, {}, remainingFilter).planNode();
+        AssertQueryBuilder(plan, duckDbQueryRunner_)
+            .connectorSessionProperty(
+                kHiveConnectorId,
+                connector::hive::HiveConfig::kOrcUseColumnNamesSession,
+                "true")
+            .split(makeHiveConnectorSplit(filePath))
+            .assertResults(sql);
+      };
+
+  std::vector<int64_t> values = {2};
+  const auto id = makeFlatVector<int64_t>(values);
+  const auto name = makeRowVector(
+      {"first", "last"},
+      {
+          makeFlatVector<std::string>({"Janet"}),
+          makeFlatVector<std::string>({"Jones"}),
+      });
+  const auto address = makeFlatVector<std::string>({"567 Maple Drive"});
+  auto vector = makeRowVector({"id", "name", "address"}, {id, name, address});
+
+  auto file = TempFilePath::create();
+  writeToFile(file->getPath(), {vector});
+
+  // Add one non-existing subfield 'middle' to the 'name' field and rename filed
+  // 'address'.
+  auto rowType =
+      ROW({"id", "name", "email"},
+          {BIGINT(),
+           ROW({"first", "middle", "last"}, {VARCHAR(), VARCHAR(), VARCHAR()}),
+           VARCHAR()});
+  assertSelectUseColumnNames(
+      rowType, "SELECT 2, ('Janet', null, 'Jones'), null", file->getPath());
+
+  // Filter pushdown on the non-existing field.
+  createDuckDbTable({vector});
+  assertSelectUseColumnNames(
+      rowType,
+      "SELECT * from tmp where false",
+      file->getPath(),
+      "not(is_null(name.middle))");
+
+  // Deletion of one subfield from the 'name' field.
+  rowType =
+      ROW({"id", "name", "address"},
+          {BIGINT(), ROW({"full"}, {VARCHAR()}), VARCHAR()});
+  assertSelectUseColumnNames(
+      rowType, "SELECT 2, row(null), '567 Maple Drive'", file->getPath());
+
+  // Filter pushdown on the non-existing subfield.
+  assertSelectUseColumnNames(
+      rowType,
+      "SELECT * from tmp where false",
+      file->getPath(),
+      "not(is_null(name.full))");
+
+  // No subfield in the 'name' field.
+  rowType = ROW({"id", "name", "address"}, {BIGINT(), ROW({}, {}), VARCHAR()});
+  const auto op = PlanBuilder()
+                      .startTableScan()
+                      .outputType(rowType)
+                      .dataColumns(rowType)
+                      .endTableScan()
+                      .planNode();
+  const auto split = makeHiveConnectorSplit(file->getPath());
+  const auto result =
+      AssertQueryBuilder(op)
+          .connectorSessionProperty(
+              kHiveConnectorId,
+              connector::hive::HiveConfig::kOrcUseColumnNamesSession,
+              "true")
+          .split(split)
+          .copyResults(pool());
+  const auto rows = result->as<RowVector>();
+  const auto expected = makeRowVector(ROW({}, {}), 1);
+  facebook::velox::test::assertEqualVectors(expected, rows->childAt(1));
+}
+
 // Tests queries that use Lazy vectors with multiple layers of wrapping.
 TEST_F(TableScanTest, constDictLazy) {
   vector_size_t size = 1'000;

--- a/velox/functions/lib/aggregates/AverageAggregateBase.cpp
+++ b/velox/functions/lib/aggregates/AverageAggregateBase.cpp
@@ -21,7 +21,8 @@ namespace facebook::velox::functions::aggregate {
 void checkAvgIntermediateType(const TypePtr& type) {
   VELOX_USER_CHECK(
       type->isRow() || type->isVarbinary(),
-      "Input type for final average must be row type or varbinary type.");
+      "Input type for final average must be row type or varbinary type, find {}",
+      type->toString());
   if (type->kind() == TypeKind::VARBINARY) {
     return;
   }

--- a/velox/functions/lib/aggregates/DecimalAggregate.h
+++ b/velox/functions/lib/aggregates/DecimalAggregate.h
@@ -78,7 +78,7 @@ class DecimalAggregate : public exec::Aggregate {
   }
 
   int32_t accumulatorAlignmentSize() const override {
-    return static_cast<int32_t>(sizeof(int128_t));
+    return alignof(LongDecimalWithOverflowState);
   }
 
   void addRawInput(
@@ -275,7 +275,9 @@ class DecimalAggregate : public exec::Aggregate {
   }
 
   virtual TResultType computeFinalValue(
-      LongDecimalWithOverflowState* accumulator) = 0;
+      LongDecimalWithOverflowState* accumulator) {
+    return 0;
+  };
 
   void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
       override {
@@ -327,11 +329,11 @@ class DecimalAggregate : public exec::Aggregate {
     }
   }
 
- private:
   inline LongDecimalWithOverflowState* decimalAccumulator(char* group) {
     return exec::Aggregate::value<LongDecimalWithOverflowState>(group);
   }
 
+ private:
   DecodedVector decodedRaw_;
   DecodedVector decodedPartial_;
 };

--- a/velox/functions/sparksql/aggregates/AverageAggregate.cpp
+++ b/velox/functions/sparksql/aggregates/AverageAggregate.cpp
@@ -16,6 +16,7 @@
 
 #include "velox/functions/sparksql/aggregates/AverageAggregate.h"
 #include "velox/functions/lib/aggregates/AverageAggregateBase.h"
+#include "velox/functions/sparksql/DecimalUtil.h"
 
 using namespace facebook::velox::functions::aggregate;
 
@@ -74,6 +75,308 @@ class AverageAggregate
   }
 };
 
+template <typename TInputType, typename TResultType>
+class DecimalAverageAggregate : public DecimalAggregate<TInputType> {
+ public:
+  explicit DecimalAverageAggregate(TypePtr resultType, TypePtr sumType)
+      : DecimalAggregate<TInputType>(resultType), sumType_(sumType) {}
+
+  void addIntermediateResults(
+      char** groups,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+    auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<int128_t>>();
+    auto countVector = baseRowVector->childAt(1)->as<SimpleVector<int64_t>>();
+    VELOX_USER_CHECK_NOT_NULL(sumVector);
+
+    if (decodedPartial_.isConstantMapping()) {
+      if (!decodedPartial_.isNullAt(0)) {
+        auto decodedIndex = decodedPartial_.index(0);
+        auto count = countVector->valueAt(decodedIndex);
+        if (sumVector->isNullAt(decodedIndex) &&
+            !countVector->isNullAt(decodedIndex) && count > 0) {
+          // Find overflow, set all groups to null.
+          rows.applyToSelected(
+              [&](vector_size_t i) { this->setNull(groups[i]); });
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          rows.applyToSelected([&](vector_size_t i) {
+            this->clearNull(groups[i]);
+            auto accumulator = this->decimalAccumulator(groups[i]);
+            mergeSumCount(accumulator, sum, count);
+          });
+        }
+      }
+    } else if (decodedPartial_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (decodedPartial_.isNullAt(i)) {
+          return;
+        }
+        auto decodedIndex = decodedPartial_.index(i);
+        auto count = countVector->valueAt(decodedIndex);
+        if (sumVector->isNullAt(decodedIndex) &&
+            !countVector->isNullAt(decodedIndex) && count > 0) {
+          this->setNull(groups[i]);
+        } else {
+          this->clearNull(groups[i]);
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto accumulator = this->decimalAccumulator(groups[i]);
+          mergeSumCount(accumulator, sum, count);
+        }
+      });
+    } else {
+      rows.applyToSelected([&](vector_size_t i) {
+        auto decodedIndex = decodedPartial_.index(i);
+        auto count = countVector->valueAt(decodedIndex);
+        if (sumVector->isNullAt(decodedIndex) &&
+            !countVector->isNullAt(decodedIndex) && count > 0) {
+          this->setNull(groups[i]);
+        } else {
+          this->clearNull(groups[i]);
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto accumulator = this->decimalAccumulator(groups[i]);
+          mergeSumCount(accumulator, sum, count);
+        }
+      });
+    }
+  }
+
+  void addSingleGroupIntermediateResults(
+      char* group,
+      const SelectivityVector& rows,
+      const std::vector<VectorPtr>& args,
+      bool /* mayPushdown */) override {
+    decodedPartial_.decode(*args[0], rows);
+    auto baseRowVector = dynamic_cast<const RowVector*>(decodedPartial_.base());
+    auto sumVector = baseRowVector->childAt(0)->as<SimpleVector<int128_t>>();
+    auto countVector = baseRowVector->childAt(1)->as<SimpleVector<int64_t>>();
+
+    if (decodedPartial_.isConstantMapping()) {
+      if (!decodedPartial_.isNullAt(0)) {
+        auto decodedIndex = decodedPartial_.index(0);
+        if (isPartialSumOverflow(sumVector, countVector, decodedIndex)) {
+          // Find overflow, just set group to null and return.
+          this->setNull(group);
+          return;
+        } else {
+          if (rows.hasSelections()) {
+            this->clearNull(group);
+          }
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto count = countVector->valueAt(decodedIndex);
+          rows.applyToSelected(
+              [&](vector_size_t i) { mergeAccumulators(group, sum, count); });
+        }
+      }
+    } else if (decodedPartial_.mayHaveNulls()) {
+      rows.applyToSelected([&](vector_size_t i) {
+        if (!decodedPartial_.isNullAt(i)) {
+          this->clearNull(group);
+          auto decodedIndex = decodedPartial_.index(i);
+          if (isPartialSumOverflow(sumVector, countVector, decodedIndex)) {
+            // Find overflow, just set group to null.
+            this->setNull(group);
+          } else {
+            auto sum = sumVector->valueAt(decodedIndex);
+            auto count = countVector->valueAt(decodedIndex);
+            mergeAccumulators(group, sum, count);
+          }
+        }
+      });
+    } else {
+      if (rows.hasSelections()) {
+        this->clearNull(group);
+      }
+      rows.applyToSelected([&](vector_size_t i) {
+        auto decodedIndex = decodedPartial_.index(i);
+        if (isPartialSumOverflow(sumVector, countVector, decodedIndex)) {
+          // Find overflow, just set group to null.
+          this->setNull(group);
+        } else {
+          auto sum = sumVector->valueAt(decodedIndex);
+          auto count = countVector->valueAt(decodedIndex);
+          mergeAccumulators(group, sum, count);
+        }
+      });
+    }
+  }
+
+  void extractAccumulators(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto rowVector = (*result)->as<RowVector>();
+    auto sumVector = rowVector->childAt(0)->asFlatVector<int128_t>();
+    auto countVector = rowVector->childAt(1)->asFlatVector<int64_t>();
+    VELOX_USER_CHECK_NOT_NULL(sumVector);
+
+    rowVector->resize(numGroups);
+    sumVector->resize(numGroups);
+    countVector->resize(numGroups);
+    rowVector->clearAllNulls();
+
+    int64_t* rawCounts = countVector->mutableRawValues();
+    int128_t* rawSums = sumVector->mutableRawValues();
+    for (auto i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      auto* accumulator = this->decimalAccumulator(group);
+      std::optional<int128_t> adjustedSum = DecimalUtil::adjustSumForOverflow(
+          accumulator->sum, accumulator->overflow);
+      if (adjustedSum.has_value()) {
+        rawCounts[i] = accumulator->count;
+        rawSums[i] = adjustedSum.value();
+      } else {
+        // Find overflow.
+        sumVector->setNull(i, true);
+        rawCounts[i] = accumulator->count;
+      }
+    }
+  }
+
+  void extractValues(char** groups, int32_t numGroups, VectorPtr* result)
+      override {
+    auto vector = (*result)->as<FlatVector<TResultType>>();
+    VELOX_CHECK(vector);
+    vector->resize(numGroups);
+    uint64_t* rawNulls = this->getRawNulls(vector);
+
+    TResultType* rawValues = vector->mutableRawValues();
+    for (int32_t i = 0; i < numGroups; ++i) {
+      char* group = groups[i];
+      auto accumulator = this->decimalAccumulator(group);
+      if (accumulator->count == 0) {
+        // In Spark, if all inputs are null, count will be 0,
+        // and the result of final avg will be null.
+        vector->setNull(i, true);
+      } else {
+        this->clearNull(rawNulls, i);
+        std::optional<TResultType> avg = computeAvg(accumulator);
+        if (avg.has_value()) {
+          rawValues[i] = avg.value();
+        } else {
+          // Find overflow.
+          vector->setNull(i, true);
+        }
+      }
+    }
+  }
+
+  std::optional<TResultType> computeAvg(
+      LongDecimalWithOverflowState* accumulator) {
+    std::optional<int128_t> validSum = DecimalUtil::adjustSumForOverflow(
+        accumulator->sum, accumulator->overflow);
+    if (!validSum.has_value()) {
+      return std::nullopt;
+    }
+
+    auto [resultPrecision, resultScale] =
+        getDecimalPrecisionScale(*this->resultType().get());
+    // Spark use DECIMAL(20,0) to represent long value.
+    const uint8_t countPrecision = 20, countScale = 0;
+    auto [sumPrecision, sumScale] =
+        getDecimalPrecisionScale(*this->sumType_.get());
+    auto [avgPrecision, avgScale] = computeResultPrecisionScale(
+        sumPrecision, sumScale, countPrecision, countScale);
+    avgScale = std::max<uint8_t>(avgScale, resultScale);
+    auto sumRescale = computeRescaleFactor(sumScale, countScale, avgScale);
+    auto countDecimal = accumulator->count;
+    int128_t avg = 0;
+
+    bool overflow = false;
+    functions::sparksql::DecimalUtil::
+        divideWithRoundUp<int128_t, int128_t, int128_t>(
+            avg, validSum.value(), countDecimal, sumRescale, overflow);
+    if (overflow) {
+      return std::nullopt;
+    }
+    TResultType rescaledValue;
+    const auto status = DecimalUtil::rescaleWithRoundUp<int128_t, TResultType>(
+        avg,
+        avgPrecision,
+        avgScale,
+        resultPrecision,
+        resultScale,
+        rescaledValue);
+    return status.ok() ? std::optional<TResultType>(rescaledValue)
+                       : std::nullopt;
+  }
+
+ private:
+  template <typename UnscaledType>
+  inline void mergeSumCount(
+      LongDecimalWithOverflowState* accumulator,
+      UnscaledType sum,
+      int64_t count) {
+    accumulator->count += count;
+    accumulator->overflow +=
+        DecimalUtil::addWithOverflow(accumulator->sum, sum, accumulator->sum);
+  }
+
+  template <bool tableHasNulls = true, class UnscaledType>
+  void mergeAccumulators(
+      char* group,
+      const UnscaledType& otherSum,
+      const int64_t& otherCount) {
+    if constexpr (tableHasNulls) {
+      exec::Aggregate::clearNull(group);
+    }
+    auto accumulator = this->decimalAccumulator(group);
+    mergeSumCount(accumulator, otherSum, otherCount);
+  }
+
+  inline static bool isPartialSumOverflow(
+      SimpleVector<int128_t>* sumVector,
+      SimpleVector<int64_t>* countVector,
+      int32_t index) {
+    return sumVector->isNullAt(index) && !countVector->isNullAt(index) &&
+        countVector->valueAt(index) > 0;
+  }
+
+  inline static uint8_t
+  computeRescaleFactor(uint8_t fromScale, uint8_t toScale, uint8_t rScale) {
+    return rScale - fromScale + toScale;
+  }
+
+  inline static std::pair<uint8_t, uint8_t> computeResultPrecisionScale(
+      const uint8_t aPrecision,
+      const uint8_t aScale,
+      const uint8_t bPrecision,
+      const uint8_t bScale) {
+    uint8_t intDig = aPrecision - aScale + bScale;
+    uint8_t scale = std::max(6, aScale + bPrecision + 1);
+    uint8_t precision = intDig + scale;
+    return functions::sparksql::DecimalUtil::adjustPrecisionScale(
+        precision, scale);
+  }
+
+  inline static std::pair<uint8_t, uint8_t> adjustPrecisionScale(
+      const uint8_t precision,
+      const uint8_t scale) {
+    VELOX_CHECK(precision >= scale);
+    if (precision <= 38) {
+      return {precision, scale};
+    } else {
+      uint8_t intDigits = precision - scale;
+      uint8_t minScaleValue = std::min(scale, (uint8_t)6);
+      uint8_t adjustedScale =
+          std::max((uint8_t)(38 - intDigits), minScaleValue);
+      return {38, adjustedScale};
+    }
+  }
+
+  DecodedVector decodedRaw_;
+  DecodedVector decodedPartial_;
+  TypePtr sumType_;
+};
+
+TypePtr getDecimalSumType(
+    const uint8_t rawInputPrecision,
+    const uint8_t rawInputScale) {
+  // This computational logic is derived from the definition of Spark SQL.
+  return DECIMAL(std::min(38, rawInputPrecision + 10), rawInputScale);
+}
+
 } // namespace
 
 /// Count is BIGINT() while sum and the final aggregates type depends on
@@ -99,13 +402,25 @@ exec::AggregateRegistrationResult registerAverage(
                              .build());
   }
 
-  signatures.push_back(exec::AggregateFunctionSignatureBuilder()
-                           .integerVariable("a_precision")
-                           .integerVariable("a_scale")
-                           .argumentType("DECIMAL(a_precision, a_scale)")
-                           .intermediateType("varbinary")
-                           .returnType("DECIMAL(a_precision, a_scale)")
-                           .build());
+  signatures.push_back(
+      exec::AggregateFunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .integerVariable("r_precision", "min(38, a_precision + 4)")
+          .integerVariable("r_scale", "min(38, a_scale + 4)")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .intermediateType("ROW(DECIMAL(38, a_scale), BIGINT)")
+          .returnType("DECIMAL(r_precision, r_scale)")
+          .build());
+
+  signatures.push_back(
+      exec::AggregateFunctionSignatureBuilder()
+          .integerVariable("a_precision")
+          .integerVariable("a_scale")
+          .argumentType("DECIMAL(a_precision, a_scale)")
+          .intermediateType("ROW(DECIMAL(a_precision, a_scale), BIGINT)")
+          .returnType("DECIMAL(a_precision, a_scale)")
+          .build());
 
   return exec::registerAggregateFunction(
       name,
@@ -118,7 +433,7 @@ exec::AggregateRegistrationResult registerAverage(
           -> std::unique_ptr<exec::Aggregate> {
         VELOX_CHECK_LE(
             argTypes.size(), 1, "{} takes at most one argument", name);
-        auto inputType = argTypes[0];
+        const auto& inputType = argTypes[0];
         if (exec::isRawInput(step)) {
           switch (inputType->kind()) {
             case TypeKind::SMALLINT:
@@ -129,16 +444,39 @@ exec::AggregateRegistrationResult registerAverage(
                   AverageAggregate<int32_t, double, double>>(resultType);
             case TypeKind::BIGINT: {
               if (inputType->isShortDecimal()) {
-                return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                auto inputPrecision = inputType->asShortDecimal().precision();
+                auto inputScale = inputType->asShortDecimal().scale();
+                auto sumType =
+                    DECIMAL(std::min(38, inputPrecision + 10), inputScale);
+                if (exec::isPartialOutput(step)) {
+                  return std::make_unique<
+                      DecimalAverageAggregate<int64_t, int64_t>>(
+                      resultType, sumType);
+                } else {
+                  if (resultType->isShortDecimal()) {
+                    return std::make_unique<
+                        DecimalAverageAggregate<int64_t, int64_t>>(
+                        resultType, sumType);
+                  } else if (resultType->isLongDecimal()) {
+                    return std::make_unique<
+                        DecimalAverageAggregate<int64_t, int128_t>>(
+                        resultType, sumType);
+                  } else {
+                    VELOX_FAIL("Result type must be decimal");
+                  }
+                }
               }
               return std::make_unique<
                   AverageAggregate<int64_t, double, double>>(resultType);
             }
             case TypeKind::HUGEINT: {
               if (inputType->isLongDecimal()) {
-                return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                auto inputPrecision = inputType->asLongDecimal().precision();
+                auto inputScale = inputType->asLongDecimal().scale();
+                auto sumType = getDecimalSumType(inputPrecision, inputScale);
+                return std::make_unique<
+                    DecimalAverageAggregate<int128_t, int128_t>>(
+                    resultType, sumType);
               }
               VELOX_NYI();
             }
@@ -162,26 +500,37 @@ exec::AggregateRegistrationResult registerAverage(
                   resultType);
             case TypeKind::DOUBLE:
             case TypeKind::ROW:
+              if (inputType->childAt(0)->isLongDecimal()) {
+                return std::make_unique<
+                    DecimalAverageAggregate<int128_t, int128_t>>(
+                    resultType, inputType->childAt(0));
+              }
               return std::make_unique<
                   AverageAggregate<int64_t, double, double>>(resultType);
             case TypeKind::BIGINT:
-              return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                  resultType);
+              VELOX_USER_CHECK(resultType->isShortDecimal());
+              return std::make_unique<
+                  DecimalAverageAggregate<int64_t, int64_t>>(
+                  resultType, inputType->childAt(0));
             case TypeKind::HUGEINT:
-              return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                  resultType);
+              VELOX_USER_CHECK(resultType->isLongDecimal());
+              return std::make_unique<
+                  DecimalAverageAggregate<int128_t, int128_t>>(
+                  resultType, inputType->childAt(0));
             case TypeKind::VARBINARY:
               if (inputType->isLongDecimal()) {
-                return std::make_unique<DecimalAverageAggregateBase<int128_t>>(
-                    resultType);
+                return std::make_unique<
+                    DecimalAverageAggregate<int128_t, int128_t>>(
+                    resultType, inputType->childAt(0));
               } else if (
                   inputType->isShortDecimal() ||
                   inputType->kind() == TypeKind::VARBINARY) {
                 // If the input and out type are VARBINARY, then the
                 // LongDecimalWithOverflowState is used and the template type
                 // does not matter.
-                return std::make_unique<DecimalAverageAggregateBase<int64_t>>(
-                    resultType);
+                return std::make_unique<
+                    DecimalAverageAggregate<int64_t, int64_t>>(
+                    resultType, inputType->childAt(0));
               }
               [[fallthrough]];
             default:

--- a/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
+++ b/velox/functions/sparksql/aggregates/tests/AverageAggregationTest.cpp
@@ -110,5 +110,152 @@ TEST_F(AverageAggregationTest, avgAllNulls) {
   assertQuery(plan, expected);
 }
 
+TEST_F(AverageAggregationTest, avgDecimal) {
+  int64_t kRescale = DecimalUtil::kPowersOfTen[4];
+  // Short decimal aggregation
+  auto shortDecimal = makeNullableFlatVector<int64_t>(
+      {1'000, 2'000, 3'000, 4'000, 5'000, std::nullopt}, DECIMAL(10, 1));
+  testAggregations(
+      {makeRowVector({shortDecimal})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({makeNullableFlatVector<int64_t>(
+          {3'000 * kRescale}, DECIMAL(14, 5))})});
+
+  // Long decimal aggregation
+  testAggregations(
+      {makeRowVector({makeNullableFlatVector<int128_t>(
+          {HugeInt::build(10, 100),
+           HugeInt::build(10, 200),
+           HugeInt::build(10, 300),
+           HugeInt::build(10, 400),
+           HugeInt::build(10, 500),
+           std::nullopt},
+          DECIMAL(23, 4))})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({makeFlatVector(
+          std::vector<int128_t>{HugeInt::build(10, 300) * kRescale},
+          DECIMAL(27, 8))})});
+
+  // The total sum overflows the max int128_t limit.
+  std::vector<int128_t> rawVector;
+  for (int i = 0; i < 10; ++i) {
+    rawVector.push_back(DecimalUtil::kLongDecimalMax);
+  }
+  testAggregations(
+      {makeRowVector({makeFlatVector<int128_t>(rawVector, DECIMAL(38, 0))})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({makeNullableFlatVector(
+          std::vector<std::optional<int128_t>>{std::nullopt},
+          DECIMAL(38, 4))})});
+
+  // The total sum underflows the min int128_t limit.
+  rawVector.clear();
+  auto underFlowTestResult = makeNullableFlatVector(
+      std::vector<std::optional<int128_t>>{std::nullopt}, DECIMAL(38, 4));
+  for (int i = 0; i < 10; ++i) {
+    rawVector.push_back(DecimalUtil::kLongDecimalMin);
+  }
+  testAggregations(
+      {makeRowVector({makeFlatVector<int128_t>(rawVector, DECIMAL(38, 0))})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({underFlowTestResult})});
+
+  // Test constant vector.
+  testAggregations(
+      {makeRowVector({makeConstant<int64_t>(100, 10, DECIMAL(10, 2))})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({makeFlatVector(
+          std::vector<int64_t>{100 * kRescale}, DECIMAL(14, 6))})});
+
+  auto newSize = shortDecimal->size() * 2;
+  auto indices = makeIndices(newSize, [&](int row) { return row / 2; });
+  auto dictVector =
+      VectorTestBase::wrapInDictionary(indices, newSize, shortDecimal);
+
+  testAggregations(
+      {makeRowVector({dictVector})},
+      {},
+      {"spark_avg(c0)"},
+      {},
+      {makeRowVector({makeFlatVector(
+          std::vector<int64_t>{3'000 * kRescale}, DECIMAL(14, 5))})});
+
+  // Decimal average aggregation with multiple groups.
+  auto inputRows = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 1}),
+           makeFlatVector<int64_t>({37220, 53450}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 2}),
+           makeFlatVector<int64_t>({10410, 9250}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3, 3}),
+           makeFlatVector<int64_t>({-12783, 0}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1, 2}),
+           makeFlatVector<int64_t>({23178, 41093}, DECIMAL(15, 2))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2, 3}),
+           makeFlatVector<int64_t>({-10023, 5290}, DECIMAL(15, 2))}),
+  };
+
+  auto expectedResult = {
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({1}),
+           makeFlatVector(std::vector<int128_t>{379493333}, DECIMAL(19, 6))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({2}),
+           makeFlatVector(std::vector<int128_t>{126825000}, DECIMAL(19, 6))}),
+      makeRowVector(
+          {makeNullableFlatVector<int32_t>({3}),
+           makeFlatVector(std::vector<int128_t>{-24976667}, DECIMAL(19, 6))})};
+
+  testAggregations(inputRows, {"c0"}, {"spark_avg(c1)"}, expectedResult);
+
+  auto valueA = HugeInt::parse("11999999998800000000");
+  auto valueB = HugeInt::parse("12000000000000000000");
+  auto longDecimalInputRows = {makeRowVector(
+      {makeNullableFlatVector<int32_t>({1, 1, 1, 1, 1, 1, 1}),
+       makeFlatVector<int128_t>(
+           {valueA, valueA, valueA, valueB, valueB, valueB, valueB},
+           DECIMAL(38, 18))})};
+
+  auto longDecimalExpectedResult = {makeRowVector(
+      {makeNullableFlatVector<int32_t>({1}),
+       makeFlatVector(
+           std::vector<int128_t>{HugeInt::parse("119999999994857142857143")},
+           DECIMAL(38, 22))})};
+
+  testAggregations(
+      longDecimalInputRows,
+      {"c0"},
+      {"spark_avg(c1)"},
+      longDecimalExpectedResult);
+}
+
+TEST_F(AverageAggregationTest, avgDecimalWithMultipleRowVectors) {
+  int64_t kRescale = DecimalUtil::kPowersOfTen[4];
+  auto inputRows = {
+      makeRowVector({makeFlatVector<int64_t>({100, 200}, DECIMAL(15, 2))}),
+      makeRowVector({makeFlatVector<int64_t>({300, 400}, DECIMAL(15, 2))}),
+      makeRowVector({makeFlatVector<int64_t>({500, 600}, DECIMAL(15, 2))}),
+  };
+
+  auto expectedResult = {makeRowVector(
+      {makeFlatVector(std::vector<int128_t>{350 * kRescale}, DECIMAL(19, 6))})};
+
+  testAggregations(inputRows, {}, {"spark_avg(c0)"}, expectedResult);
+}
+
 } // namespace
 } // namespace facebook::velox::functions::aggregate::sparksql::test


### PR DESCRIPTION
Decimal could be represented as FixedLengthByteArrays or ByteArrays in parquet files. FixedLengthByteArrays and ByteArrays could be encoded with DeltaByteArray encoding.

PR adds support for reading such Decimal columns.