### PR TITLE
fix: Fix Arrow larget strig import may overflow

### DIFF
--- a/velox/vector/arrow/Bridge.cpp
+++ b/velox/vector/arrow/Bridge.cpp
@@ -621,6 +621,16 @@ VectorPtr createStringFlatVector(
   bool shouldAcquireStringBuffer = false;
 
   for (size_t i = 0; i < length; ++i) {
+    if constexpr (!std::is_same_v<TOffset, int32_t>) {
+      auto rowBytes = offsets[i + 1] - offsets[i];
+      VELOX_CHECK(
+          rowBytes >= std::numeric_limits<int32_t>::min() &&
+          rowBytes <= std::numeric_limits<int32_t>::max(),
+          "Offset difference (rowBytes = {}) out of int32_t range at index {}",
+          rowBytes,
+          i);
+    }
+
     rawStringViews[i] =
         StringView(values + offsets[i], offsets[i + 1] - offsets[i]);
     shouldAcquireStringBuffer |= !rawStringViews[i].isInline();


### PR DESCRIPTION
After this PR https://github.com/facebookincubator/velox/pull/14359, Arrow supports large string data type, but the length data type is int64_t, it may overflow Velox StringView supports length int32_t, causing undefined behavior. 

Further more, if velox should support large string, if user use LargeString data type, they may request the string size more that int32_t range.